### PR TITLE
Daemon threads for polling std input/output pipes that shut down more cleanly

### DIFF
--- a/processfamily/__init__.py
+++ b/processfamily/__init__.py
@@ -102,7 +102,7 @@ class _ChildProcessHost(object):
         sys.stdout = open(os.devnull, 'w')
 
         self._stdout_lock = threading.RLock()
-        self._sys_in_thread = threading.Thread(target=self._sys_in_thread_target, name="pf_%s_stdin" % child_process.name)
+        self._sys_in_thread = threading.Thread(target=self._sys_in_thread_target, name="pf_%s_stdin" % repr(child_process))
         self._sys_in_thread.daemon = True
         self._should_stop = False
 
@@ -150,7 +150,7 @@ class _ChildProcessHost(object):
 
         self._should_stop = True
         self._started_event.wait(1)
-        stop_thread = threading.Thread(target=self._stop_thread_target, name="pf_%s_stop" % self.child_process.name)
+        stop_thread = threading.Thread(target=self._stop_thread_target, name="pf_%s_stop" % repr(self.child_process))
         stop_thread.daemon = True
         stop_thread.start()
         self._stopped_event.wait(3)

--- a/processfamily/threads.py
+++ b/processfamily/threads.py
@@ -128,8 +128,11 @@ def log_thread_tracebacks(threads, stop_event=None, finished_event=None, logleve
     logger.log(loglevel, "Preparing to shut down %d threads; generating tracebacks", len(threads))
     for (thread, frame) in find_thread_frames():
         if thread in threads:
-            logger.log(loglevel, "Preparing to shut down thread %r", thread)
-            logger.log(loglevel, "".join(traceback.format_stack(frame)))
+            if thread.daemon:
+                logger.log(loglevel, "Preparing to shut down daemon thread %r", thread)
+            else:
+                logger.log(loglevel, "Preparing to shut down thread %r", thread)
+                logger.log(loglevel, "".join(traceback.format_stack(frame)))
             if stop_event and stop_event.is_set():
                 logger.log(loglevel, "Told to stop tracebacks; aborting")
                 break


### PR DESCRIPTION
Mark these as daemon threads and don't provide tracebacks; they just sit in readline anyway