### PR TITLE
Support nested jobs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 setup(
     name='processfamily',
-    version='0.3',
+    version='0.4',
     packages = find_packages(),
     license='Apache License, Version 2.0',
     description='A library for launching, maintaining, and terminating a family of long-lived python child processes on Windows and *nix.',


### PR DESCRIPTION
As of Windows 8 / Server 2012, Job Objects can be nested. This means that the strict constraint I was enforcing is not actually always necessary. This change makes the code more optimistic - attempting to create a Job Object and only raising an exception if it fails.

See https://msdn.microsoft.com/en-us/library/windows/desktop/hh448388(v=vs.85).aspx. 