### PR TITLE
Dont try to kill dead processes

### DIFF
--- a/processfamily/__init__.py
+++ b/processfamily/__init__.py
@@ -728,7 +728,8 @@ class ProcessFamily(object):
         command_processes = []
         try:
             for child_process in self.child_processes:
-                command_processes.append(child_process.stop_child(end_time))
+                if not child_process.is_stopped():
+                    command_processes.append(child_process.stop_child(end_time))
             for c in command_processes:
                 # ping the process
                 c.next()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 setup(
     name='processfamily',
-    version='0.5',
+    version='0.6',
     packages = find_packages(),
     license='Apache License, Version 2.0',
     description='A library for launching, maintaining, and terminating a family of long-lived python child processes on Windows and *nix.',


### PR DESCRIPTION
This causes an access denied error with the signal strategy if the child is already dead.