### PR TITLE
Better startup failure handling

### DIFF
--- a/processfamily/__init__.py
+++ b/processfamily/__init__.py
@@ -503,7 +503,7 @@ class ForkingChildSignalStrategy(SignalStrategy):
     def monitor_child_startup(self, end_time):
         """generator method to monitor process startup, with the first yield after sending a ping,
         the next after receiving a response, and stopping after cleanup"""
-        while (self._process_instance.poll() is None or not os.path.exists(self.process_family.pid_file)) and time.time() < end_time:
+        while (self._process_instance.poll() is None) and time.time() < end_time:
             # Python 2.7 has the timeout parameter for wait, but it is not documented
             # try:
             #     subprocess.Popen().wait(end_time - time.time())


### PR DESCRIPTION
With a processfamily set up to start Apache, if it fails (because something else is listening on the port, etc), then this would give an error message about not being able to find the PID file. This makes that message a lot clearer.