### PR TITLE
Replace dependency on python-prctl with ctypes calls

### DIFF
--- a/processfamily/__init__.py
+++ b/processfamily/__init__.py
@@ -29,7 +29,7 @@ if sys.platform.startswith('win'):
 
     from processfamily import win32Popen
 else:
-    import prctl
+    from . import ctypes_prctl as prctl
 
 SIGNAL_NAMES = {getattr(signal, k): k for k in dir(signal) if k.startswith("SIG")}
 

--- a/processfamily/ctypes_prctl.py
+++ b/processfamily/ctypes_prctl.py
@@ -1,0 +1,39 @@
+"""A subset of the operations that can be performed on a process provided by the prctl system call"""
+
+from ctypes import CDLL, c_int, byref, create_string_buffer
+from ctypes.util import find_library
+
+libc = CDLL(find_library('c'))
+
+PR_SET_PDEATHSIG = 1
+PR_GET_PDEATHSIG = 2
+
+PR_SET_NAME = 15
+PR_GET_NAME = 16
+
+def _prctl(option, arg2=0, arg3=0, arg4=0, arg5=0):
+    """Calls the libc prctl function, with the given command option and arguments
+    return values should be passed by reference"""
+    return libc.prctl(option, arg2, arg3, arg4, arg5)
+
+def set_pdeathsig(pdeathsig):
+    """Set the parent process death signal of the calling process to pdeathsig (either a signal value in the range 1..maxsig, or 0 to claer)
+    This is the signal that the calling process will get when its parent dies.
+    This value is cleared for the child of a fork and when executing a set-user-ID or set-group-ID binary"""
+    return _prctl(PR_SET_PDEATHSIG, pdeathsig)
+
+def get_pdeathsig():
+    """Return the current value of the parent process death signal"""
+    result = c_int()
+    _prctl(PR_GET_PDEATHSIG, byref(result))
+    return result.value
+
+def set_name(name):
+    """Set the name of the calling thread. name can be up to 16 bytes long"""
+    return _prctl(PR_SET_NAME, create_string_buffer(name, 16))
+
+def get_name():
+    """Return the name of the calling thread"""
+    result = create_string_buffer(16)
+    _prctl(PR_GET_NAME, byref(result))
+    return result.value

--- a/processfamily/test/FunkyWebServer.py
+++ b/processfamily/test/FunkyWebServer.py
@@ -23,8 +23,7 @@ if sys.platform.startswith('win'):
     import win32job
     import win32api
 else:
-    import prctl
-
+    from .. import ctypes_prctl as prctl
 def crash():
     """
     crash the Python interpreter...

--- a/processfamily/test_prctl.py
+++ b/processfamily/test_prctl.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+import ctypes_prctl
+try:
+    import prctl
+except ImportError as prctl_import_error:
+    prctl = None
+import mmap
+import os
+import signal
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+class TestCtypesPrctl(unittest.TestSuite):
+    prctl_module = ctypes_prctl
+    prctl_module_name = 'ctypes_prctl'
+
+    def test_pdeathsig_consistent(self):
+        # this doesn't actually check that the process death signal changes, just that the function seems to work consistently
+        assert self.prctl_module.get_pdeathsig() == 0
+        self.prctl_module.set_pdeathsig(signal.SIGKILL)
+        assert self.prctl_module.get_pdeathsig() == signal.SIGKILL
+        self.prctl_module.set_pdeathsig(0)
+        assert self.prctl_module.get_pdeathsig() == 0
+
+    def test_pdeathsig_works(self):
+        fd, tmpfile = tempfile.mkstemp()
+        os.write(fd, '\x00' * mmap.PAGESIZE)
+        os.lseek(fd, 0, os.SEEK_SET)
+        buf = mmap.mmap(fd, mmap.PAGESIZE, mmap.MAP_SHARED, mmap.PROT_READ)
+        CHILD_SIGNAL = signal.SIGTERM
+        KILL_PARENT_WITH_SIGNAL = signal.SIGTERM
+        try:
+            args = [sys.executable, __file__, 'run_parent', self.prctl_module_name, tmpfile, str(CHILD_SIGNAL)]
+            parent_pid = os.spawnv(os.P_NOWAIT, sys.executable, args)
+            time.sleep(0.2)
+            child_pid_line = buf.readline()
+            child_pid = int(child_pid_line.strip())
+            os.kill(parent_pid, KILL_PARENT_WITH_SIGNAL)
+            _, exit_info = os.waitpid(parent_pid, 0)
+            exit_code, received_signal = exit_info >> 8, exit_info & 0xff
+            assert exit_code == 0
+            assert received_signal == KILL_PARENT_WITH_SIGNAL
+            time.sleep(0.2)
+            buf.seek(50, os.SEEK_SET)
+            child_signal_line = buf.readline()
+            child_signum = int(child_signal_line.strip())
+            assert child_signum == CHILD_SIGNAL
+        finally:
+            os.close(fd)
+            if os.path.exists(tmpfile):
+                os.remove(tmpfile)
+
+    def test_name_consistent(self):
+        # this doesn't actually check that the process name changes, just that the function seems to work consistently
+        default = os.path.basename(sys.executable)
+        assert self.prctl_module.get_name() == default
+        self.prctl_module.set_name(default+'-prctl')
+        assert self.prctl_module.get_name() == default+'-prctl'
+        self.prctl_module.set_name(default)
+        assert self.prctl_module.get_name() == default
+
+if prctl is not None:
+    class TestPythonPrctl(TestCtypesPrctl):
+        prctl_module = prctl
+        prctl_module_name = 'python-prctl'
+
+def try_signalling_child_on_death(prctl_module, buf, child_signal):
+    # in the parent process
+    child_pid = os.fork()
+    if not child_pid:
+        # in the child process
+        prctl_module.set_pdeathsig(child_signal)
+        got_signal = threading.Event()
+        def handle_signal(signum, frame):
+            buf.seek(50, os.SEEK_SET)
+            buf.write('%d\n' % signum)
+            buf.flush()
+            got_signal.set()
+        signal.signal(child_signal, handle_signal)
+        got_signal.wait(10)
+        if got_signal.is_set():
+            return
+        sys.exit(5)
+    else:
+        buf.write('%d\n' % child_pid)
+        buf.flush()
+        time.sleep(2)
+        sys.exit(3)
+
+if __name__ == '__main__':
+    if sys.argv[1] == 'run_parent':
+        prctl_module_name, tmpfile, child_signal = sys.argv[2], sys.argv[3], sys.argv[4]
+        if prctl_module_name == 'ctypes_prctl':
+            import ctypes_prctl as prctl_module
+        elif prctl_module_name == 'python-prctl':
+            import prctl as prctl_module
+        fd = os.open(tmpfile, os.O_RDWR)
+        buf = mmap.mmap(fd, mmap.PAGESIZE, mmap.MAP_SHARED, mmap.PROT_WRITE)
+        try:
+            try_signalling_child_on_death(prctl_module, buf, int(child_signal))
+        finally:
+            os.close(fd)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'Programming Language :: Python :: 2 :: Only',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires = ["json-rpc", "affinity"] + (['pywin32', "mozprocess"] if sys.platform.startswith("win") else ['python-prctl']),
+    install_requires = ["json-rpc", "affinity"] + (['pywin32', "mozprocess"] if sys.platform.startswith("win") else []),
     extras_require = {
         'tests': ['nose', 'requests'] + (['py-exe-builder'] if sys.platform.startswith("win") else []),
     }


### PR DESCRIPTION
The python-prctl library is under the GPL, whereas this library is Apache-2.0 licensed, so it's better not to use it.

We only use the `prctl` module for setting the process death signal child processes receive when their parents die, and for setting process names for convenience in testing.

This change adds the required functions and simply uses a `ctypes` call to run them

There are also unit tests that do weird things with mmap to make themselves fairly selfcontained, and that also run against python-prctl if present