### PR TITLE
Futurize

### DIFF
--- a/processfamily/__init__.py
+++ b/processfamily/__init__.py
@@ -24,10 +24,7 @@ import argparse
 import shlex
 import os
 import jsonrpc
-try:
-    import queue
-except ImportError:
-    import queue as queue
+import queue
 import pkgutil
 from processfamily.threads import stop_threads
 from processfamily.processes import kill_process, process_exists, set_process_affinity, cpu_count

--- a/processfamily/__init__.py
+++ b/processfamily/__init__.py
@@ -1,4 +1,15 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import next
+from builtins import range
+from builtins import *
+from builtins import object
 __author__ = 'matth'
 
 import threading
@@ -16,7 +27,7 @@ import jsonrpc
 try:
     import queue
 except ImportError:
-    import Queue as queue
+    import queue as queue
 import pkgutil
 from processfamily.threads import stop_threads
 from processfamily.processes import kill_process, process_exists, set_processor_affinity, cpu_count
@@ -354,7 +365,7 @@ class ChildCommsStrategy(object):
         finally:
             #Unstick any waiting command threads:
             with self._rsp_queues_lock:
-                for q in self._rsp_queues.values():
+                for q in list(self._rsp_queues.values()):
                     if q.empty():
                         q.put_nowait(None)
                 self._rsp_queues = None

--- a/processfamily/__init__.py
+++ b/processfamily/__init__.py
@@ -30,7 +30,7 @@ except ImportError:
     import queue as queue
 import pkgutil
 from processfamily.threads import stop_threads
-from processfamily.processes import kill_process, process_exists, set_processor_affinity, cpu_count
+from processfamily.processes import kill_process, process_exists, set_process_affinity, cpu_count
 import signal
 import functools
 
@@ -676,11 +676,11 @@ class ProcessFamily(object):
 
     def set_parent_affinity_mask(self):
         if self.CPU_AFFINITY_STRATEGY == CPU_AFFINITY_STRATEGY_PARENT_INCLUDED:
-            set_processor_affinity([0])
+            set_process_affinity({0})
 
     def set_child_affinity_mask(self, pid, child_index):
         i = child_index+1 if self.CPU_AFFINITY_STRATEGY == CPU_AFFINITY_STRATEGY_PARENT_INCLUDED else child_index
-        set_processor_affinity([i%self.cpu_count], pid=pid)
+        set_process_affinity({i%self.cpu_count}, pid=pid)
 
     def start(self, timeout=30):
         if self.child_processes:

--- a/processfamily/_winprocess_ctypes.py
+++ b/processfamily/_winprocess_ctypes.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 # Extends mozprocess with some code from winappdgb:
 # These parts are mostly from: http://winappdbg.sourceforge.net/
 #
@@ -31,6 +35,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 from mozprocess.winprocess import *
 from ctypes import cast, pointer, c_size_t, c_ssize_t, byref
 import sys

--- a/processfamily/affinity.py
+++ b/processfamily/affinity.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+
+import os
+import sys
+
+if hasattr(os, 'sched_setaffinity'):
+    sched_setaffinity = os.sched_setaffinity
+    sched_getaffinity = os.sched_getaffinity
+elif sys.platform.startswith("win"):
+    # Use win32process from pywin32
+    import win32api
+    import win32con
+    import win32process
+
+    def _cores_to_mask(cores):
+        """converts a list of cores to a mask if necessary"""
+        mask = 0
+        for core in cores:
+            mask |= 1 << core
+        return mask
+
+
+    def _mask_to_cores(mask):
+        """converts a mask to a list of cores"""
+        cores = set()
+        i = 0
+        while mask:
+            if mask % 2:
+                cores.add(i)
+            mask >>= 1
+            i += 1
+        return cores
+
+    def sched_getaffinity(pid):
+        pid = pid or os.getpid()
+        handle = win32api.OpenProcess(win32con.PROCESS_QUERY_INFORMATION, False, pid)
+        return _mask_to_cores(win32process.GetProcessAffinityMask(handle)[0])
+
+    def sched_setaffinity(pid, mask):
+        pid = pid or os.getpid()
+        handle = win32api.OpenProcess(win32con.PROCESS_SET_INFORMATION, False, pid)
+        win32process.SetProcessAffinityMask(handle, _cores_to_mask(mask))
+else:
+    def set_process_affinity_mask(*args, **kwargs):
+        raise NotImplementedError()
+    def get_process_affinity_mask(*args, **kwargs):
+        raise NotImplementedError()

--- a/processfamily/affinity.py
+++ b/processfamily/affinity.py
@@ -19,7 +19,6 @@ elif sys.platform.startswith("win"):
     import win32process
 
     def _cores_to_mask(cores):
-        """converts a list of cores to a mask if necessary"""
         mask = 0
         for core in cores:
             mask |= 1 << core

--- a/processfamily/affinity.py
+++ b/processfamily/affinity.py
@@ -46,7 +46,7 @@ elif sys.platform.startswith("win"):
         handle = win32api.OpenProcess(win32con.PROCESS_SET_INFORMATION, False, pid)
         win32process.SetProcessAffinityMask(handle, _cores_to_mask(mask))
 else:
-    def set_process_affinity_mask(*args, **kwargs):
+    def sched_setaffinity(*args, **kwargs):
         raise NotImplementedError()
-    def get_process_affinity_mask(*args, **kwargs):
+    def sched_getaffinity(*args, **kwargs):
         raise NotImplementedError()

--- a/processfamily/ctypes_prctl.py
+++ b/processfamily/ctypes_prctl.py
@@ -1,5 +1,12 @@
 """A subset of the operations that can be performed on a process provided by the prctl system call"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from ctypes import CDLL, c_int, byref, create_string_buffer
 from ctypes.util import find_library
 

--- a/processfamily/env.py
+++ b/processfamily/env.py
@@ -1,0 +1,69 @@
+"""Most of this file has been copied from j5pythonpath in the framework"""
+
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+
+from future.utils import text_to_native_str, PY3, native
+
+import locale
+import sys
+import os
+
+def text_to_fs(t):
+    """convert text to native_str, using the file system encoding, preserving None"""
+    # PY2COMPAT: used to handle python2 requiring native str in encoding, and for type consistency of file system paths
+    # also handle use during startup when filesystemencoding not yet initialized, within this module
+    if t is None:
+        return t
+    return text_to_native_str(t, sys.getfilesystemencoding() or locale.getpreferredencoding())
+
+def fs_to_text(s):
+    """convert a native_str to text, using the file system encoding, preserving None"""
+    # PY2COMPAT: used to handle python2 requiring native str in encoding, and for type consistency of file system paths
+    if s is None:
+        return s
+    if PY3:
+        return s
+    # note that there isn't a native_str_to_text: this is the equivalent
+    # also handle use during startup when filesystemencoding not yet initialized, within this module
+    return native(s).decode(sys.getfilesystemencoding() or locale.getpreferredencoding())
+
+# FUTURIZE_REVIEW: how to handle environment variables and filesystem encodings on Python 2
+#
+# We are using the filesystem encoding for the environment variables on Python 2 to retain existing behaviour.
+# (Py3 is better: https://docs.python.org/3/library/os.html#file-names-command-line-arguments-and-environment-variables)
+#
+# However, this doesn't actually work properly for characters that can't be encoded with the filesystemencoding.
+# For further info on this, see https://gist.github.com/davidfraser/b338ba07a6f058535a2d9786986ed8a3
+
+_env_default = object()
+def get_env(key, default=_env_default):
+    """the same as os.environ[key] or os.environ.get(key, default), but key must be text and is converted with text_to_fs, and response is converted with fs_to_text"""
+    key = text_to_fs(key)
+    if default is _env_default:
+        return fs_to_text(os.environ[key])
+    result = fs_to_text(os.environ.get(key, None))
+    return default if result is None else result
+
+def has_env(key):
+    """the same as key in os.environ, but key must be text and is converted with text_to_fs"""
+    return text_to_fs(key) in os.environ
+
+def set_env(key, value):
+    """the same as os.environ[key] = value, but key and value must be text and are converted with text_to_fs"""
+    os.environ[text_to_fs(key)] = text_to_fs(value)
+
+def update_env(d, update_copy_of_env=None):
+    """the same as os.environ.update(d), but keys and values of dict must be text and are converted with text_to_fs"""
+    if update_copy_of_env is None:
+        update_copy_of_env = os.environ
+    update_copy_of_env.update({text_to_fs(key): text_to_fs(value) for key, value in d.items()})
+
+def get_env_dict():
+    """returns a copy of os.environ where keys and values are text, converted with text_to_fs"""
+    return {text_to_fs(key): text_to_fs(value) for key, value in os.environ.items()}

--- a/processfamily/futurecompat.py
+++ b/processfamily/futurecompat.py
@@ -14,6 +14,7 @@ import locale
 import sys
 import os
 
+
 def text_to_fs(t):
     """convert text to native_str, using the file system encoding, preserving None"""
     # PY2COMPAT: used to handle python2 requiring native str in encoding, and for type consistency of file system paths
@@ -21,6 +22,7 @@ def text_to_fs(t):
     if t is None:
         return t
     return text_to_native_str(t, sys.getfilesystemencoding() or locale.getpreferredencoding())
+
 
 def fs_to_text(s):
     """convert a native_str to text, using the file system encoding, preserving None"""
@@ -41,6 +43,7 @@ def fs_to_text(s):
 # However, this doesn't actually work properly for characters that can't be encoded with the filesystemencoding.
 # For further info on this, see https://gist.github.com/davidfraser/b338ba07a6f058535a2d9786986ed8a3
 
+
 _env_default = object()
 def get_env(key, default=_env_default):
     """the same as os.environ[key] or os.environ.get(key, default), but key must be text and is converted with text_to_fs, and response is converted with fs_to_text"""
@@ -50,13 +53,16 @@ def get_env(key, default=_env_default):
     result = fs_to_text(os.environ.get(key, None))
     return default if result is None else result
 
+
 def has_env(key):
     """the same as key in os.environ, but key must be text and is converted with text_to_fs"""
     return text_to_fs(key) in os.environ
 
+
 def set_env(key, value):
     """the same as os.environ[key] = value, but key and value must be text and are converted with text_to_fs"""
     os.environ[text_to_fs(key)] = text_to_fs(value)
+
 
 def update_env(d, update_copy_of_env=None):
     """the same as os.environ.update(d), but keys and values of dict must be text and are converted with text_to_fs"""
@@ -64,6 +70,12 @@ def update_env(d, update_copy_of_env=None):
         update_copy_of_env = os.environ
     update_copy_of_env.update({text_to_fs(key): text_to_fs(value) for key, value in d.items()})
 
+
 def get_env_dict():
     """returns a copy of os.environ where keys and values are text, converted with text_to_fs"""
     return {text_to_fs(key): text_to_fs(value) for key, value in os.environ.items()}
+
+
+def list_to_native_str(l):
+    """Convert a list of text to a list of native_str"""
+    return [text_to_native_str(i) for i in l]

--- a/processfamily/processes.py
+++ b/processfamily/processes.py
@@ -1,3 +1,11 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import *
 __author__ = 'matth'
 
 import os

--- a/processfamily/processes.py
+++ b/processfamily/processes.py
@@ -11,7 +11,7 @@ __author__ = 'matth'
 import os
 import sys
 import logging
-import affinity
+from processfamily import affinity
 
 if sys.platform.startswith("win"):
     import win32api
@@ -109,41 +109,19 @@ else:
         return multiprocessing.cpu_count()
 
 
-def _affinity_mask_to_list(mask):
-    """converts a mask to a list of cores"""
-    cores = []
-    i = 0
-    while mask:
-        if mask % 2:
-            cores.append(i)
-        mask >>= 1
-        i += 1
-    return cores
 
-def _create_affinity_mask(mask_or_list):
-    """converts a list of cores to a mask if necessary"""
-    if isinstance(mask_or_list, int):
-        return mask_or_list
-    cores = mask_or_list
-    mask = 0
-    for core in cores:
-        mask |= 1 << core
-    return mask
-
-def get_processor_affinity(pid=None):
+def get_process_affinity(pid=None):
     """Gets the process_affinity cores either for the current process or the given pid. Returns a list of cores"""
-    mask = affinity.get_process_affinity_mask(pid or 0)
-    return _affinity_mask_to_list(mask)
+    return affinity.get_process_affinity_mask(pid or 0)
 
-def set_processor_affinity(mask, pid=None):
+def set_process_affinity(mask, pid=None):
     """Sets the process_affinity to the given cores, either for the current process or the given pid. mask can be an affinity mask or list of cores. Returns success"""
-    mask = _create_affinity_mask(mask)
     pid = pid or 0
-    previous_mask = affinity.set_process_affinity_mask(pid, mask)
-    current_mask = affinity.get_process_affinity_mask(pid)
-    current_mask_str = ", ".join(str(i) for i in _affinity_mask_to_list(current_mask))
-    if current_mask != mask:
-        request_mask_str = ", ".join(str(i) for i in _affinity_mask_to_list(mask))
+    affinity.sched_setaffinity(pid, mask)
+    current_mask = affinity.sched_getaffinity(pid)
+    current_mask_str = ", ".join(str(i) for i in current_mask)
+    if set(current_mask) != set(mask):
+        request_mask_str = ", ".join(str(i) for i in mask)
         logger.warning("Set process affinity for pid %d to cores %s unsuccessful: actually set to %s", pid, request_mask_str, current_mask_str)
         return False
     else:

--- a/processfamily/processes.py
+++ b/processfamily/processes.py
@@ -112,7 +112,7 @@ else:
 
 def get_process_affinity(pid=None):
     """Gets the process_affinity cores either for the current process or the given pid. Returns a list of cores"""
-    return affinity.get_process_affinity_mask(pid or 0)
+    return affinity.sched_getaffinity(pid or 0)
 
 def set_process_affinity(mask, pid=None):
     """Sets the process_affinity to the given cores, either for the current process or the given pid. mask can be an affinity mask or list of cores. Returns success"""

--- a/processfamily/processes.py
+++ b/processfamily/processes.py
@@ -120,7 +120,7 @@ def set_process_affinity(mask, pid=None):
     affinity.sched_setaffinity(pid, mask)
     current_mask = affinity.sched_getaffinity(pid)
     current_mask_str = ", ".join(str(i) for i in current_mask)
-    if set(current_mask) != set(mask):
+    if current_mask != set(mask):
         request_mask_str = ", ".join(str(i) for i in mask)
         logger.warning("Set process affinity for pid %d to cores %s unsuccessful: actually set to %s", pid, request_mask_str, current_mask_str)
         return False

--- a/processfamily/test/ChildProcess.py
+++ b/processfamily/test/ChildProcess.py
@@ -1,3 +1,10 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __author__ = 'matth'
 
 import os

--- a/processfamily/test/Config.py
+++ b/processfamily/test/Config.py
@@ -10,7 +10,9 @@ __author__ = 'matth'
 import os
 import sys
 
+from processfamily.env import get_env
+
 pythonw_exe = os.path.join(sys.prefix, "pythonw.exe")
 svc_name = 'ProcessFamilyTest'
 def get_starting_port_nr():
-    return int(os.environ.get("PROCESSFAMILY_TESTS_STARTING_PORT_NR", "9080"))
+    return int(get_env("PROCESSFAMILY_TESTS_STARTING_PORT_NR", "9080"))

--- a/processfamily/test/Config.py
+++ b/processfamily/test/Config.py
@@ -10,7 +10,7 @@ __author__ = 'matth'
 import os
 import sys
 
-from processfamily.env import get_env
+from processfamily.futurecompat import get_env
 
 pythonw_exe = os.path.join(sys.prefix, "pythonw.exe")
 svc_name = 'ProcessFamilyTest'

--- a/processfamily/test/Config.py
+++ b/processfamily/test/Config.py
@@ -1,3 +1,10 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __author__ = 'matth'
 
 import os

--- a/processfamily/test/ExeBuilder.py
+++ b/processfamily/test/ExeBuilder.py
@@ -1,3 +1,10 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __author__ = 'matth'
 import sys
 import os

--- a/processfamily/test/FunkyWebServer.py
+++ b/processfamily/test/FunkyWebServer.py
@@ -29,7 +29,7 @@ def crash():
     crash the Python interpreter...
     see https://wiki.python.org/moin/CrashingPython
     """
-    exec CodeType(0, 5, 8, 0, "hello moshe", (), (), (), "", "", 0, "")
+    exec(CodeType(0, 5, 8, 0, "hello moshe", (), (), (), "", "", 0, ""))
 
 if sys.platform.startswith('win'):
     #Using a PyDLL here instead of a WinDLL causes the GIL to be acquired:
@@ -222,7 +222,7 @@ class FunkyWebServer(object):
                     logging.info("Had to terminate %d child processes", terminated)
                 else:
                     logging.info("Didn't have to terminate child processes, they stopped gracefully")
-        except Exception, e:
+        except Exception as e:
             self.child_processes_terminated = e
             logging.error("Error terminating child processes: %r", e)
 

--- a/processfamily/test/FunkyWebServer.py
+++ b/processfamily/test/FunkyWebServer.py
@@ -1,14 +1,22 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 __author__ = 'matth'
 
-import BaseHTTPServer
-import SocketServer
-import urlparse
+import http.server
+import socketserver
+import urllib.parse
 import argparse
 from processfamily.test import Config
 import logging
 import logging.handlers
 import threading
-import thread
+import _thread
 import os
 from types import CodeType
 import json
@@ -53,15 +61,15 @@ else:
         _libc.sleep(timeout)
         logging.info("Released GIL")
 
-class MyHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+class MyHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
 
     funkyserver = None
     http_server = None
 
     def do_GET(self):
         """Serve a GET request."""
-        parsed_url = urlparse.urlparse(self.path)
-        params = urlparse.parse_qs(parsed_url.query)
+        parsed_url = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed_url.query)
         path = parsed_url.path
         if path.startswith('/stop'):
             # stop children before we return a response
@@ -79,7 +87,7 @@ class MyHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             if path.startswith('/stop'):
                 self.funkyserver.stop()
             if path.startswith('/interrupt_main'):
-                thread.interrupt_main()
+                _thread.interrupt_main()
             if path.startswith('/exit'):
                 os._exit(1)
             if path.startswith('/hold_gil'):
@@ -157,10 +165,10 @@ class MyHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
         logging.info("%s - - " + format, self.client_address[0], *args)
 
-class MyHTTPServer(SocketServer.ThreadingMixIn, BaseHTTPServer.HTTPServer):
+class MyHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     def __init__(self, port):
         MyHTTPRequestHandler.http_server = self
-        BaseHTTPServer.HTTPServer.__init__(self, ("", port), MyHTTPRequestHandler)
+        http.server.HTTPServer.__init__(self, ("", port), MyHTTPRequestHandler)
 
     def handle_error(self, request, client_address):
         logging.error('Exception happened during processing of request from %s:\n%s', client_address, _traceback_str())

--- a/processfamily/test/ParentProcess.py
+++ b/processfamily/test/ParentProcess.py
@@ -11,6 +11,9 @@ __author__ = 'matth'
 
 import os
 import sys
+
+from processfamily.env import get_env
+
 if __name__ == '__main__':
     #python issue 18298
     if sys.platform.startswith('win'):
@@ -89,7 +92,7 @@ class ProcessFamilyForTests(processfamily.ProcessFamily):
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
-    STARTUP_TIMEOUT = int(os.environ.get("STARTUP_TIMEOUT", "") or "10")
+    STARTUP_TIMEOUT = int(get_env("STARTUP_TIMEOUT", "") or "10")
     logging.info("Starting")
     try:
         try:

--- a/processfamily/test/ParentProcess.py
+++ b/processfamily/test/ParentProcess.py
@@ -1,4 +1,12 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import *
 __author__ = 'matth'
 
 import os

--- a/processfamily/test/ParentProcess.py
+++ b/processfamily/test/ParentProcess.py
@@ -12,7 +12,7 @@ __author__ = 'matth'
 import os
 import sys
 
-from processfamily.env import get_env
+from processfamily.futurecompat import get_env
 
 if __name__ == '__main__':
     #python issue 18298

--- a/processfamily/test/Win32Service.py
+++ b/processfamily/test/Win32Service.py
@@ -1,5 +1,10 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __author__ = 'matth'
 
 import os

--- a/processfamily/test/Win32Service.py
+++ b/processfamily/test/Win32Service.py
@@ -17,7 +17,7 @@ if __name__ != '__main__':
     with open(pid_filename, "w") as pid_f:
         pid_f.write("%s\n" % pid)
 
-from . import win32service
+import win32service
 import win32serviceutil
 import win32api
 import win32con

--- a/processfamily/test/Win32Service.py
+++ b/processfamily/test/Win32Service.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 __author__ = 'matth'
 
 import os
@@ -10,7 +12,7 @@ if __name__ != '__main__':
     with open(pid_filename, "w") as pid_f:
         pid_f.write("%s\n" % pid)
 
-import win32service
+from . import win32service
 import win32serviceutil
 import win32api
 import win32con
@@ -74,20 +76,20 @@ def usage():
         fname = os.path.split(sys.argv[0])[1]
     except:
         fname = sys.argv[0]
-    print "Usage: '%s [options] install|update|remove|start [...]|stop|restart [...]|debug [...]'" % fname
-    print "Options for 'install' and 'update' commands only:"
-    print " --username domain\\username : The Username the service is to run under"
-    print " --password password : The password for the username"
-    print " --startup [manual|auto|disabled|delayed] : How the service starts, default = manual"
-    print " --interactive : Allow the service to interact with the desktop."
-    print " --perfmonini file: .ini file to use for registering performance monitor data"
-    print " --perfmondll file: .dll file to use when querying the service for"
-    print "   performance data, default = perfmondata.dll"
-    print "Options for 'start' and 'stop' commands only:"
-    print " --wait seconds: Wait for the service to actually start or stop."
-    print "                 If you specify --wait with the 'stop' option, the service"
-    print "                 and all dependent services will be stopped, each waiting"
-    print "                 the specified period."
+    print("Usage: '%s [options] install|update|remove|start [...]|stop|restart [...]|debug [...]'" % fname)
+    print("Options for 'install' and 'update' commands only:")
+    print(" --username domain\\username : The Username the service is to run under")
+    print(" --password password : The password for the username")
+    print(" --startup [manual|auto|disabled|delayed] : How the service starts, default = manual")
+    print(" --interactive : Allow the service to interact with the desktop.")
+    print(" --perfmonini file: .ini file to use for registering performance monitor data")
+    print(" --perfmondll file: .dll file to use when querying the service for")
+    print("   performance data, default = perfmondata.dll")
+    print("Options for 'start' and 'stop' commands only:")
+    print(" --wait seconds: Wait for the service to actually start or stop.")
+    print("                 If you specify --wait with the 'stop' option, the service")
+    print("                 and all dependent services will be stopped, each waiting")
+    print("                 the specified period.")
     sys.exit(1)
 
 def HandleCommandLine():

--- a/processfamily/test/__init__.py
+++ b/processfamily/test/__init__.py
@@ -1,1 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __author__ = 'matth'

--- a/processfamily/test/parent_launcher.py
+++ b/processfamily/test/parent_launcher.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'Administrator'
 
 import subprocess
@@ -19,13 +20,13 @@ if __name__ == '__main__':
     def wait_for_end():
         try:
             while True:
-                print 'Waiting'
+                print('Waiting')
                 if parent_process.poll() is not None:
-                    print 'Ended'
+                    print('Ended')
                     return
                 time.sleep(1)
         except Exception as e:
-            print _traceback_str()
+            print(_traceback_str())
 
     t = threading.Thread(target=parent_process.wait)
     t.start()
@@ -34,4 +35,4 @@ if __name__ == '__main__':
             t.join(1)
     except Exception as e:
         kill_process(parent_process.pid)
-    print "Done"
+    print("Done")

--- a/processfamily/test/parent_launcher.py
+++ b/processfamily/test/parent_launcher.py
@@ -1,4 +1,10 @@
 from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __author__ = 'Administrator'
 
 import subprocess

--- a/processfamily/test/pipes_example_code/child.py
+++ b/processfamily/test/pipes_example_code/child.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'Administrator'
 
 import os
@@ -38,7 +39,7 @@ pipeoutfd = msvcrt.open_osfhandle(int(out_file_handle), os.O_WRONLY)
 # Read from pipe
 # Note:  Could be done with os.read/os.close directly, instead of os.fdopen
 pipein = os.fdopen(pipeinfd, 'r')
-print pipein.read()
+print(pipein.read())
 pipein.close()
 
 pipeout = os.fdopen(pipeoutfd, 'w')

--- a/processfamily/test/pipes_example_code/child.py
+++ b/processfamily/test/pipes_example_code/child.py
@@ -1,4 +1,10 @@
 from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __author__ = 'Administrator'
 
 import os

--- a/processfamily/test/pipes_example_code/parent.py
+++ b/processfamily/test/pipes_example_code/parent.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import subprocess
 import msvcrt
@@ -22,7 +23,7 @@ pipefh.write("Hello from parent.")
 pipefh.close()
 
 pipein = os.fdopen(pipe2out, 'r')
-print pipein.read()
+print(pipein.read())
 pipein.close()
 
 # Wait for the child to finish

--- a/processfamily/test/pipes_example_code/parent.py
+++ b/processfamily/test/pipes_example_code/parent.py
@@ -1,4 +1,11 @@
 from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import *
 import os
 import subprocess
 import msvcrt

--- a/processfamily/test_prctl.py
+++ b/processfamily/test_prctl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-import ctypes_prctl
+from __future__ import absolute_import
+from . import ctypes_prctl
 try:
     import prctl
 except ImportError as prctl_import_error:
@@ -95,7 +96,7 @@ if __name__ == '__main__':
     if sys.argv[1] == 'run_parent':
         prctl_module_name, tmpfile, child_signal = sys.argv[2], sys.argv[3], sys.argv[4]
         if prctl_module_name == 'ctypes_prctl':
-            import ctypes_prctl as prctl_module
+            from . import ctypes_prctl as prctl_module
         elif prctl_module_name == 'python-prctl':
             import prctl as prctl_module
         fd = os.open(tmpfile, os.O_RDWR)

--- a/processfamily/test_prctl.py
+++ b/processfamily/test_prctl.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import *
 from . import ctypes_prctl
 try:
     import prctl

--- a/processfamily/test_processfamily.py
+++ b/processfamily/test_processfamily.py
@@ -115,7 +115,7 @@ class _BaseProcessFamilyFunkyWebServerTestSuite(unittest.TestCase):
                     s = socket.socket()
                     try:
                         s.connect(("localhost", Config.get_starting_port_nr()+i))
-                    except socket.error, e:
+                    except socket.error as e:
                         still_waiting = True
                         break
                 finally:

--- a/processfamily/test_processfamily.py
+++ b/processfamily/test_processfamily.py
@@ -1,3 +1,12 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from builtins import *
 __author__ = 'matth'
 
 import unittest
@@ -105,7 +114,7 @@ class _BaseProcessFamilyFunkyWebServerTestSuite(unittest.TestCase):
         #Wait up to 15 secs for the all ports to be available (the parent might wait 10 for a middle child):
         start_time = time.time()
         still_waiting = True
-        ports_to_wait = range(4) if wait_for_children else [0]
+        ports_to_wait = list(range(4)) if wait_for_children else [0]
         if not wait_for_middle_child:
             ports_to_wait.remove(2)
         while still_waiting and time.time() - start_time < 15:

--- a/processfamily/test_processfamily.py
+++ b/processfamily/test_processfamily.py
@@ -7,6 +7,7 @@ standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import *
+from future.utils import text_to_native_str
 __author__ = 'matth'
 
 import unittest
@@ -23,6 +24,8 @@ from processfamily.processes import process_exists, kill_process, AccessDeniedEr
 from processfamily import _traceback_str
 import signal
 import threading
+
+from processfamily.env import get_env_dict
 
 if sys.platform.startswith('win'):
     from processfamily._winprocess_ctypes import CAN_USE_EXTENDED_STARTUPINFO, CREATE_BREAKAWAY_FROM_JOB
@@ -411,9 +414,9 @@ class NormalSubprocessTests(_BaseProcessFamilyFunkyWebServerTestSuite):
         kwargs={}
         if sys.platform.startswith('win'):
             kwargs['creationflags'] = CREATE_BREAKAWAY_FROM_JOB
-        environ = os.environ.copy()
+        environ = get_env_dict()
         if timeout:
-            environ["STARTUP_TIMEOUT"] = str(timeout)
+            environ[text_to_native_str("STARTUP_TIMEOUT")] = text_to_native_str(timeout)
         self.parent_process = subprocess.Popen(
             [sys.executable, self.get_path_to_ParentProcessPy()],
             close_fds=True, env=environ, **kwargs)

--- a/processfamily/test_processfamily.py
+++ b/processfamily/test_processfamily.py
@@ -25,7 +25,7 @@ from processfamily import _traceback_str
 import signal
 import threading
 
-from processfamily.env import get_env_dict
+from processfamily.futurecompat import get_env_dict, list_to_native_str
 
 if sys.platform.startswith('win'):
     from processfamily._winprocess_ctypes import CAN_USE_EXTENDED_STARTUPINFO, CREATE_BREAKAWAY_FROM_JOB
@@ -418,7 +418,7 @@ class NormalSubprocessTests(_BaseProcessFamilyFunkyWebServerTestSuite):
         if timeout:
             environ[text_to_native_str("STARTUP_TIMEOUT")] = text_to_native_str(timeout)
         self.parent_process = subprocess.Popen(
-            [sys.executable, self.get_path_to_ParentProcessPy()],
+            list_to_native_str([sys.executable, self.get_path_to_ParentProcessPy()]),
             close_fds=True, env=environ, **kwargs)
         threading.Thread(target=self.parent_process.communicate).start()
 
@@ -452,7 +452,8 @@ if sys.platform.startswith('win'):
         def setUpClass(cls, service_username=None):
             cls.send_stop_and_then_wait_for_service_to_stop_ignore_errors()
             cls.service_exe = build_service_exe()
-            subprocess.check_call([cls.service_exe] + (["--username", service_username] if service_username else []) + ["install"])
+            cmd = [cls.service_exe] + (["--username", service_username] if service_username else []) + ["install"]
+            subprocess.check_call(list_to_native_str(cmd))
 
         @classmethod
         def tearDownClass(cls):

--- a/processfamily/win32Popen.py
+++ b/processfamily/win32Popen.py
@@ -1,3 +1,13 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from past.builtins import basestring
+from builtins import *
+from builtins import object
 __author__ = 'matth'
 
 from processfamily import _winprocess_ctypes
@@ -36,7 +46,7 @@ class HandlesOverCommandLinePopen(subprocess.Popen):
 
     def __init__(self, args,  bufsize=0, stdin=None, stdout=None, stderr=None,
                  universal_newlines=False, close_fds=False, timeout_for_child_stream_duplication_event=30, **kwargs):
-        if not isinstance(bufsize, (int, long)):
+        if not isinstance(bufsize, (int, int)):
             raise TypeError("bufsize must be an integer")
 
         self.commandline_passed = {}

--- a/processfamily/win32Popen.py
+++ b/processfamily/win32Popen.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+
+native_int = int
+
 from future import standard_library
 standard_library.install_aliases()
 from builtins import str
@@ -46,7 +49,7 @@ class HandlesOverCommandLinePopen(subprocess.Popen):
 
     def __init__(self, args,  bufsize=0, stdin=None, stdout=None, stderr=None,
                  universal_newlines=False, close_fds=False, timeout_for_child_stream_duplication_event=30, **kwargs):
-        if not isinstance(bufsize, (int, int)):
+        if not isinstance(bufsize, int):
             raise TypeError("bufsize must be an integer")
 
         self.commandline_passed = {}
@@ -278,7 +281,9 @@ class ProcThreadAttributeHandleListPopen(subprocess.Popen):
         if None not in (p2cread, c2pwrite, errwrite):
             if close_fds:
                 HandleArray = _winprocess_ctypes.HANDLE * 3
-                handles_to_inherit = HandleArray(int(p2cread), int(c2pwrite), int(errwrite))
+                # PY2COMPAT new_int doesn't seem to know how to convert file handles to int.
+                # So we use the "native_int" instead.
+                handles_to_inherit = HandleArray(native_int(p2cread), native_int(c2pwrite), native_int(errwrite))
 
                 attribute_list_data = (
                     (
@@ -289,9 +294,11 @@ class ProcThreadAttributeHandleListPopen(subprocess.Popen):
                 inherit_handles = 1
 
             startupinfo.dwFlags |= _winprocess_ctypes.STARTF_USESTDHANDLES
-            startupinfo.hStdInput = int(p2cread)
-            startupinfo.hStdOutput = int(c2pwrite)
-            startupinfo.hStdError = int(errwrite)
+            # PY2COMPAT new_int doesn't seem to know how to convert file handles to int.
+            # So we use the "native_int" instead.
+            startupinfo.hStdInput = native_int(p2cread)
+            startupinfo.hStdOutput = native_int(c2pwrite)
+            startupinfo.hStdError = native_int(errwrite)
 
         if _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
             attribute_list = _winprocess_ctypes.ProcThreadAttributeList(attribute_list_data)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __author__ = 'matth'
 
 from distutils.core import setup

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires = ["json-rpc", "affinity"] + (['pywin32', "mozprocess"] if sys.platform.startswith("win") else []),
+    install_requires = ["json-rpc"] + (['pywin32', "mozprocess"] if sys.platform.startswith("win") else []),
     extras_require = {
         'tests': ['nose', 'requests'] + (['py-exe-builder'] if sys.platform.startswith("win") else []),
     }


### PR DESCRIPTION
Futurize the code to make it work on both Python 2 and 3. This doesn't fix the module completely, but it does make it work better.

### Status

- The tests not related to Service Control pass on Python 2. 
- None of the tests Pass on Python 3.
- j5start on Python 2 works
- j5start on Python 3 works better than it did before (but it is still broken, due to other reasons).

### Changes

- Futurize Stage 1 & Stage 2
- Create a futurecompat file that creates allows you to access environment variables in a Python 2 and Python 3 compatible way
- Use native_int to convert file handles, because new_int doesn't know how to do that
- Remove the affinity module and re-implement it's functionality (because it doesn't support python 3)
  - The methods were renamed and their behaviour modified so that they correspond with `os.sched_(get|set)affinity`
- Convert `text` to `native_str` in Popen calls that broke some tests.

### TODO
- [ ] run `list_to_native_str` on all Popen calls