### PR TITLE
Python3 compat

### DIFF
--- a/processfamily/win32Popen.py
+++ b/processfamily/win32Popen.py
@@ -354,7 +354,7 @@ class ProcThreadAttributeHandleListPopen(subprocess.Popen):
                 _close_in_parent(errwrite)
 
         self._child_created = True
-        self._handle = hp.value if PY3 else hp
+        self._handle = subprocess.Handle(hp) if hasattr(subprocess, 'Handle') else hp
         self._thread = ht
         self.pid = pid
         self.tid = tid

--- a/processfamily/win32Popen.py
+++ b/processfamily/win32Popen.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 native_int = int
 
 from future import standard_library
-from future.utils import PY3
 standard_library.install_aliases()
 from builtins import str
 from past.builtins import basestring

--- a/processfamily/win32Popen.py
+++ b/processfamily/win32Popen.py
@@ -244,6 +244,25 @@ class ProcThreadAttributeHandleListPopen(subprocess.Popen):
              c2pread, c2pwrite,
              errread, errwrite) = args_tuple
             to_close = None
+        elif sys.hexversion > 0x03040000: # 3.4.0 and later
+            (args, executable, preexec_fn, close_fds,
+                                pass_fds, cwd, env,
+                                input_startupinfo, creationflags, shell,
+                                p2cread, p2cwrite,
+                                c2pread, c2pwrite,
+                                errread, errwrite,
+                                restore_signals, start_new_session) = args_tuple
+            #TODO: the to_close set used to be passed back on python 2, so we need to work out how to properly handle it
+            to_close = set()
+            to_close.add(p2cread)
+            # if stdin == PIPE:
+            #     to_close.add(p2cwrite)
+            to_close.add(c2pwrite)
+            # if stdout == PIPE:
+            #     to_close.add(c2pread)
+            to_close.add(errwrite)
+            # if stderr == PIPE:
+            #     to_close.add(errread)
         else: # 2.7.6 and later
             (args, executable, preexec_fn, close_fds,
              cwd, env, universal_newlines, input_startupinfo,

--- a/processfamily/win32Popen.py
+++ b/processfamily/win32Popen.py
@@ -252,17 +252,16 @@ class ProcThreadAttributeHandleListPopen(subprocess.Popen):
                                 c2pread, c2pwrite,
                                 errread, errwrite,
                                 restore_signals, start_new_session) = args_tuple
-            #TODO: the to_close set used to be passed back on python 2, so we need to work out how to properly handle it
             to_close = set()
             to_close.add(p2cread)
-            # if stdin == PIPE:
-            #     to_close.add(p2cwrite)
+            if p2cwrite is not None:
+                to_close.add(p2cwrite)
             to_close.add(c2pwrite)
-            # if stdout == PIPE:
-            #     to_close.add(c2pread)
+            if c2pread is not None:
+                to_close.add(c2pread)
             to_close.add(errwrite)
-            # if stderr == PIPE:
-            #     to_close.add(errread)
+            if errread is not None:
+                to_close.add(errread)
         else: # 2.7.6 and later
             (args, executable, preexec_fn, close_fds,
              cwd, env, universal_newlines, input_startupinfo,

--- a/processfamily/win32Popen.py
+++ b/processfamily/win32Popen.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 native_int = int
 
 from future import standard_library
+from future.utils import PY3
 standard_library.install_aliases()
 from builtins import str
 from past.builtins import basestring
@@ -335,7 +336,7 @@ class ProcThreadAttributeHandleListPopen(subprocess.Popen):
                 _close_in_parent(errwrite)
 
         self._child_created = True
-        self._handle = hp
+        self._handle = hp.value if PY3 else hp
         self._thread = ht
         self.pid = pid
         self.tid = tid


### PR DESCRIPTION
On python 3, the process handle is actually saved as a Handle object. Also the method signature of _execute_child has changed, so I had to handle that, and manually create one of the objects that used to be passed through in it.

Busy running the unit tests now to verify that I haven't broken anything new.