### PR TITLE
Fix a small encoding issue that affects python 3

### DIFF
--- a/processfamily/__init__.py
+++ b/processfamily/__init__.py
@@ -458,7 +458,7 @@ class ProcessFamilyRPCProtocolStrategy(ChildCommsStrategy):
 
         try:
             with self._stdin_lock:
-                self._process_instance.stdin.write("%s\n" % req)
+                self._process_instance.stdin.write(("%s\n" % req).encode('utf8'))
                 self._process_instance.stdin.flush()
                 if command == 'stop':
                     #Now close the stream - we are done


### PR DESCRIPTION
stdin in this case accepts bytes on python 3. The encoding works fine on python 2 as well.