### PR TITLE
WIP: Fix some unittests

### DIFF
--- a/processfamily/test/FunkyWebServer.py
+++ b/processfamily/test/FunkyWebServer.py
@@ -6,6 +6,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *
 from builtins import object
+from future.utils import PY2
 __author__ = 'matth'
 
 import http.server
@@ -213,6 +214,11 @@ class FunkyWebServer(object):
         if cls._open_file_handle is None and cls.process_number == 0:
             logging.info("Opening a file and keeping it open")
             cls._open_file_handle = open(os.path.join(os.path.dirname(__file__), 'tmp', 'testfile.txt'), 'w')
+            # The tests expect file descriptors to be inheritable, but from Python 3.4 onwards, file descriptors
+            # are set to be not inheritable by default.
+            if not PY2:
+                os.set_inheritable(cls._open_file_handle.fileno(), True)
+
 
     def run(self):
         with self.httpd_lock:

--- a/processfamily/test/FunkyWebServer.py
+++ b/processfamily/test/FunkyWebServer.py
@@ -128,7 +128,7 @@ class MyHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         return "OK"
 
     def _to_json_rsp(self, o):
-        return json.dumps(o, indent=3, encoding='UTF-8')
+        return json.dumps(o, indent=3).encode('utf-8')
 
     def send_head(self, content):
         """Common code for GET and HEAD commands.

--- a/processfamily/test/ParentProcess.py
+++ b/processfamily/test/ParentProcess.py
@@ -105,13 +105,13 @@ if __name__ == '__main__':
                     family.start(timeout=STARTUP_TIMEOUT)
                     server_thread = threading.Thread(target=server.run)
                     server_thread.start()
-                    while server_thread.isAlive():
+                    while server_thread.is_alive():
                         server_thread.join(1)
                 except KeyboardInterrupt:
                     logging.info("Stopping...")
                     server.stop()
             finally:
-                if server_thread and server_thread.isAlive():
+                if server_thread and server_thread.is_alive():
                     server_thread.join(5)
         finally:
             stop_threads()

--- a/processfamily/test/ParentProcess.py
+++ b/processfamily/test/ParentProcess.py
@@ -20,11 +20,12 @@ if __name__ == '__main__':
         #When running under pythonw.exe you can end up with 'invalid' files for stdin+stdout+stder
         #For this reason, I just open devnull for them
         # (this was a problem because the HTTPServer tries to write to stderr
-        if sys.stderr.fileno() < 0:
+        # In Python 2 the fileno() < 0 in Python 3 the "files" are just None
+        if sys.stderr is None or sys.stderr.fileno() < 0:
             sys.stderr = open(os.devnull, "w")
-        if sys.stdout.fileno() < 0:
+        if sys.stdout is None or sys.stdout.fileno() < 0:
             sys.stdout = open(os.devnull, "w")
-        if sys.stdin.fileno() < 0:
+        if sys.stdin is None or sys.stdin.fileno() < 0:
             sys.stdin = open(os.devnull, "r")
 
     pid = os.getpid()

--- a/processfamily/test/parent_launcher.py
+++ b/processfamily/test/parent_launcher.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     t = threading.Thread(target=parent_process.wait)
     t.start()
     try:
-        while t.isAlive():
+        while t.is_alive():
             t.join(1)
     except Exception as e:
         kill_process(parent_process.pid)

--- a/processfamily/test_processfamily.py
+++ b/processfamily/test_processfamily.py
@@ -469,8 +469,8 @@ class TestFunkyWebServer():
         send_parent_http_command("crash")
 
     def test_parent_interrupt_main(self, fws):
-        if fws.skip_intterupt_main:
-            pytest.skip(fws.skip_intterupt_main)
+        if fws.skip_interrupt_main:
+            pytest.skip(fws.skip_interrupt_main)
         fws.start_up()
         send_parent_http_command("interrupt_main")
 

--- a/processfamily/test_processfamily.py
+++ b/processfamily/test_processfamily.py
@@ -8,7 +8,7 @@ standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import *
-from future.utils import text_to_native_str
+from future.utils import text_to_native_str, native_str, PY2
 __author__ = 'matth'
 
 import unittest
@@ -34,7 +34,8 @@ if sys.platform.startswith('win'):
     from processfamily._winprocess_ctypes import CAN_USE_EXTENDED_STARTUPINFO, CREATE_BREAKAWAY_FROM_JOB
     import win32service
     import win32serviceutil
-    from processfamily.test.ExeBuilder import build_service_exe
+    if PY2:
+        from processfamily.test.ExeBuilder import build_service_exe
     from processfamily.processes import USE_PROCESS_QUERY_LIMITED_INFORMATION
 
 

--- a/processfamily/test_processfamily.py
+++ b/processfamily/test_processfamily.py
@@ -27,50 +27,209 @@ import signal
 import threading
 import pytest
 
-
 from processfamily.futurecompat import get_env_dict, list_to_native_str
+
 
 if sys.platform.startswith('win'):
     from processfamily._winprocess_ctypes import CAN_USE_EXTENDED_STARTUPINFO, CREATE_BREAKAWAY_FROM_JOB
+    import win32service
+    import win32serviceutil
+    from processfamily.test.ExeBuilder import build_service_exe
+    from processfamily.processes import USE_PROCESS_QUERY_LIMITED_INFORMATION
 
-class _BaseProcessFamilyFunkyWebServerTestSuite(unittest.TestCase):
 
-    skip_crash_test = None
+pid_dir = os.path.join(os.path.dirname(__file__), 'test', 'tmp', 'pid')
+path_to_ParentProcessPy = os.path.join(os.path.dirname(__file__), 'test', 'ParentProcess.py')
 
-    def setUp(self):
-        self.pid_dir = os.path.join(os.path.dirname(__file__), 'test', 'tmp', 'pid')
-        if not os.path.exists(self.pid_dir):
-            os.makedirs(self.pid_dir)
-        for pid_file in self.get_pid_files():
-            with open(pid_file, "r") as f:
-                pid = f.read().strip()
-            if pid and self.process_exists_or_access_denied(int(pid)):
-                logging.warning(
-                    ("Process with pid %s is stilling running. This could be a problem " + \
-                    "(but it might be a new process with a recycled pid so I'm not killing it).") % pid )
-            else:
-                os.remove(pid_file)
-        self.check_server_ports_unbound()
 
-    def process_exists_or_access_denied(self, pid):
-        try:
-            return process_exists(pid)
-        except AccessDeniedError as e:
-            #It is most likely that this process does exist!
-            return True
+def process_exists_or_access_denied(pid):
+    try:
+        return process_exists(pid)
+    except AccessDeniedError as e:
+        # It is most likely that this process does exist!
+        return True
 
-    def kill_process_ignore_access_denied(self, pid):
-        try:
-            return kill_process(pid)
-        except AccessDeniedError as e:
-            #Can't do anything about this
-            pass
 
-    def try_and_stop_everything_for_tear_down(self):
-        #Override this if you can do something about stopping everything
+def kill_process_ignore_access_denied(pid):
+    try:
+        return kill_process(pid)
+    except AccessDeniedError as e:
+        # Can't do anything about this
         pass
 
-    def tearDown(self):
+
+def assert_middle_child_port_unbound():
+    port = Config.get_starting_port_nr()+2
+    logging.info("Checking for ability to bind to port %d", port)
+    serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        if not sys.platform.startswith('win'):
+            #On linux I need this setting cos we are starting and stopping things
+            #so frequently that they are still in a STOP_WAIT state when I get here
+            serversocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        serversocket.bind(("", port))
+    except Exception as e:
+        pytest.fail("Middle child port is not unbound as expected")
+    finally:
+        serversocket.close()
+
+
+def get_pid_files():
+    return glob.glob(os.path.join(pid_dir, "*.pid"))
+
+
+def kill_parent():
+    for pid_file in get_pid_files():
+        if os.path.basename(pid_file).startswith('c'):
+            continue
+        with open(pid_file, "r") as f:
+            pid = f.read().strip()
+        kill_process(int(pid))
+
+
+def check_server_ports_unbound():
+    bound_ports = []
+    for pnumber in range(4):
+        port = Config.get_starting_port_nr() + pnumber
+        #I just try and bind to the server port and see if I have a problem:
+        logging.info("Checking for ability to bind to port %d", port)
+        serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            if not sys.platform.startswith('win'):
+                #On linux I need this setting cos we are starting and stopping things
+                #so frequently that they are still in a STOP_WAIT state when I get here
+                serversocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            serversocket.bind(("", port))
+        except Exception as e:
+            bound_ports.append(port)
+        finally:
+            serversocket.close()
+    assert not bound_ports, "The following ports are still bound: %s" % ', '.join([str(p) for p in bound_ports])
+    
+
+def send_http_command(port, command, params=None, **kwargs):
+    r = requests.get('http://localhost:%d/%s' % (port, command), params=params, **kwargs)
+    j = r.json
+    if callable(j):
+        return j()
+    else:
+        #This is the old requests api:
+        return j
+
+
+def send_parent_http_command(command, params=None, **kwargs):
+    return send_http_command(Config.get_starting_port_nr(), command, params=params, **kwargs)
+
+
+def send_middle_child_http_command(command, params=None, **kwargs):
+    return send_http_command(Config.get_starting_port_nr()+2, command, params=params, **kwargs)
+
+
+def freeze_up_middle_child():
+    #First check that we can do this fast (i.e. things aren't stuttering because of environment):
+    for i in range(5):
+        send_middle_child_http_command("", timeout=1)
+    send_middle_child_http_command("hold_gil?t=%d" % (60*10)) #Freeze up for 10 minutes
+    while True:
+        #Try and do this request until it takes longer than 1 sec - this would mean that we have successfully got stuck
+        try:
+            send_middle_child_http_command("", timeout=1)
+        except requests.exceptions.Timeout as t:
+            break
+
+
+def wait_for_process_to_stop(process, timeout):
+    if process is None:
+        logging.info("No process to wait for")
+        return
+    logging.info("Waiting for process (%d) to finish", process.pid)
+    start_time = time.time()
+    while time.time()-start_time < timeout:
+        if process.poll() is None:
+            time.sleep(0.3)
+        else:
+            return
+
+
+def check_stop(force_kills=0, timeout=None):
+    """Checks that a stop succeeds, and that the number of child processes that had to be terminated is as expected"""
+    params = {"timeout": str(timeout)} if timeout else {}
+    child_processes_terminated = send_parent_http_command("stop", params=params)
+    if child_processes_terminated != str(force_kills):
+        raise ValueError("Stop received, but parent reports %r instead of %r child processes terminated",
+                         child_processes_terminated, force_kills)
+
+
+def CanOpenSCManager():
+    s = None
+    try:
+        s = win32service.OpenSCManager(None, None, win32service.SC_MANAGER_ALL_ACCESS)
+    except:
+        return False
+    else:
+        return True
+    finally:
+        if s:
+            win32service.CloseServiceHandle(s)
+
+
+def send_stop_and_then_wait_for_service_to_stop_ignore_errors():
+    try:
+        win32serviceutil.StopService(Config.svc_name)
+        wait_for_service_to_stop(20)
+    except Exception as e:
+        pass
+
+
+def wait_for_service_to_stop(timeout):
+    start_time = time.time()
+    while time.time()-start_time < timeout:
+        if win32serviceutil.QueryServiceStatus(Config.svc_name)[1] != win32service.SERVICE_STOPPED:
+            time.sleep(0.3)
+
+def grant_network_service_rights(folder, rights):
+    try:
+        subprocess.check_call(["cmd.exe", "/C", "icacls", folder, "/grant", "NETWORK SERVICE:(OI)(CI)%s" % rights])
+    except Exception as e:
+        logging.warning("icacls command returned a non-zero response for folder/file '%s'")
+
+
+class FunkyWebServerFixtureBase(object):
+    skip_crash_test = None
+    skip_interrupt_main = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def start_parent_process(self, timeout):
+        raise NotImplementedError()
+
+    def wait_for_parent_to_stop(self, timeout):
+        raise NotImplementedError()
+
+    def try_and_stop_everything_for_tear_down(self):
+        # Override this if you can do something about stopping everything
+        pass
+
+    @classmethod
+    def shouldSkip(cls):
+        return None
+
+    def setup(self):
+        if not os.path.exists(pid_dir):
+            os.makedirs(pid_dir)
+        for pid_file in get_pid_files():
+            with open(pid_file, "r") as f:
+                pid = f.read().strip()
+            if pid and process_exists_or_access_denied(int(pid)):
+                logging.warning(
+                    ("Process with pid %s is stilling running. This could be a problem " + \
+                     "(but it might be a new process with a recycled pid so I'm not killing it).") % pid)
+            else:
+                os.remove(pid_file)
+        check_server_ports_unbound()
+
+    def teardown(self):
         command_file = os.path.join(os.path.dirname(__file__), 'test', 'tmp', 'command.txt')
         if os.path.exists(command_file):
             os.remove(command_file)
@@ -80,20 +239,20 @@ class _BaseProcessFamilyFunkyWebServerTestSuite(unittest.TestCase):
         #Now check that no processes are left over:
         start_time = time.time()
         processes_left_running = []
-        for pid_file in self.get_pid_files():
+        for pid_file in get_pid_files():
             with open(pid_file, "r") as f:
                 pid = f.read().strip()
             if pid:
-                while self.process_exists_or_access_denied(int(pid)) and time.time() - start_time < 5:
+                while process_exists_or_access_denied(int(pid)) and time.time() - start_time < 5:
                     time.sleep(0.3)
-                if self.process_exists_or_access_denied(int(pid)):
+                if process_exists_or_access_denied(int(pid)):
                     processes_left_running.append(int(pid))
             os.remove(pid_file)
 
         if processes_left_running:
             for pid in processes_left_running:
                 try:
-                    self.kill_process_ignore_access_denied(pid)
+                    kill_process_ignore_access_denied(pid)
                 except Exception as e:
                     logging.warning("Error killing process with pid %d: %s", pid, _traceback_str())
 
@@ -101,12 +260,11 @@ class _BaseProcessFamilyFunkyWebServerTestSuite(unittest.TestCase):
 
             start_time = time.time()
             for pid in processes_left_running:
-                while self.process_exists_or_access_denied(int(pid)) and time.time() - start_time < 40:
+                while process_exists_or_access_denied(int(pid)) and time.time() - start_time < 40:
                     time.sleep(0.3)
 
-        self.check_server_ports_unbound()
-        self.assertFalse(processes_left_running, msg="There should have been no PIDs left running but there were: %s" % (', '.join([str(p) for p in processes_left_running])))
-
+        check_server_ports_unbound()
+        assert not processes_left_running, "There should have been no PIDs left running but there were: %s" % (', '.join([str(p) for p in processes_left_running]))
 
     def start_up(self, test_command=None, wait_for_middle_child=True, wait_for_children=True, parent_timeout=None):
         command_file = os.path.join(os.path.dirname(__file__), 'test', 'tmp', 'command.txt')
@@ -137,280 +295,20 @@ class _BaseProcessFamilyFunkyWebServerTestSuite(unittest.TestCase):
                     s.close()
             if still_waiting:
                 time.sleep(0.3)
-        self.assertFalse(still_waiting, "Waited 10 seconds and some http ports are still not accessible")
+        assert not still_waiting, "Waited 10 seconds and some http ports are still not accessible"
 
-    def assert_middle_child_port_unbound(self):
-        port = Config.get_starting_port_nr()+2
-        logging.info("Checking for ability to bind to port %d", port)
-        serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            if not sys.platform.startswith('win'):
-                #On linux I need this setting cos we are starting and stopping things
-                #so frequently that they are still in a STOP_WAIT state when I get here
-                serversocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            serversocket.bind(("", port))
-        except Exception as e:
-            self.fail("Middle child port is not unbound as expected")
-        finally:
-            serversocket.close()
-
-    def get_pid_files(self):
-        return glob.glob(os.path.join(self.pid_dir, "*.pid"))
-
-    def kill_parent(self):
-        for pid_file in self.get_pid_files():
-            if os.path.basename(pid_file).startswith('c'):
-                continue
-            with open(pid_file, "r") as f:
-                pid = f.read().strip()
-            kill_process(int(pid))
-
-    def check_stop(self, force_kills=0, timeout=None):
-        """Checks that a stop succeeds, and that the number of child processes that had to be terminated is as expected"""
-        params = {"timeout": str(timeout)} if timeout else {}
-        child_processes_terminated = self.send_parent_http_command("stop", params=params)
-        if child_processes_terminated != str(force_kills):
-            raise ValueError("Stop received, but parent reports %r instead of %r child processes terminated",
-                             child_processes_terminated, force_kills)
-
-    def test_parent_stop(self):
-        self.start_up()
-        self.check_stop()
-
-    def test_parent_exit(self):
-        self.start_up()
-        self.send_parent_http_command("exit")
-
-    def test_parent_crash(self):
-        if self.skip_crash_test:
-            self.skipTest(self.skip_crash_test)
-        self.start_up()
-        self.send_parent_http_command("crash")
-
-    def test_parent_interrupt_main(self):
-        self.start_up()
-        self.send_parent_http_command("interrupt_main")
-
-    def test_parent_kill(self):
-        self.start_up()
-        self.kill_parent()
-
-    def test_parent_stop_child_locked_up(self):
-        self.start_up()
-        self.freeze_up_middle_child()
-        self.check_stop(1, timeout=5)
-        #This needs time to wait for the child for 10 seconds:
-        self.wait_for_parent_to_stop(11)
-
-    def test_parent_exit_child_locked_up(self):
-        self.start_up()
-        self.freeze_up_middle_child()
-        self.send_parent_http_command("exit")
-
-    def test_parent_crash_child_locked_up(self):
-        if self.skip_crash_test:
-            self.skipTest(self.skip_crash_test)
-        self.start_up()
-        self.freeze_up_middle_child()
-        self.send_parent_http_command("crash")
-
-    def test_parent_interrupt_main_child_locked_up(self):
-        self.start_up()
-        self.freeze_up_middle_child()
-        self.send_parent_http_command("interrupt_main")
-        #This needs time to wait for the child for 10 seconds:
-        self.wait_for_parent_to_stop(11)
-
-    def test_parent_kill_child_locked_up(self):
-        self.start_up()
-        self.freeze_up_middle_child()
-        self.kill_parent()
-
-    def test_parent_exit_child_locked_up(self):
-        self.start_up()
-        self.freeze_up_middle_child()
-        self.send_parent_http_command("exit")
-
-    def test_child_exit_on_start(self):
-        self.start_up(test_command='child_exit_on_start', wait_for_middle_child=False)
-        self.assert_middle_child_port_unbound()
-        self.check_stop()
-
-    def test_child_error_during_run(self):
-        self.start_up(test_command='child_error_during_run', wait_for_middle_child=False)
-        self.check_stop()
-
-    def test_child_freeze_on_start(self):
-        self.start_up(test_command='child_freeze_on_start', wait_for_middle_child=False, parent_timeout=2)
-        self.assert_middle_child_port_unbound()
-        self.check_stop(1, timeout=5)
-
-    def test_child_error_on_start(self):
-        self.start_up(test_command='child_error_on_start', wait_for_middle_child=False)
-        self.assert_middle_child_port_unbound()
-        self.check_stop()
-
-    def test_child_error_during_init(self):
-        self.start_up(test_command='child_error_during_init', wait_for_middle_child=False)
-        self.assert_middle_child_port_unbound()
-        self.check_stop()
-
-    def test_child_freeze_during_init(self):
-        self.start_up(test_command='child_freeze_during_init', wait_for_middle_child=False, parent_timeout=2)
-        self.assert_middle_child_port_unbound()
-        self.check_stop(1, timeout=5)
-        self.wait_for_parent_to_stop(11)
-
-    def test_child_crash_on_start(self):
-        if self.skip_crash_test:
-            self.skipTest(self.skip_crash_test)
-        self.start_up(test_command='child_crash_on_start', wait_for_middle_child=False)
-        self.assert_middle_child_port_unbound()
-        self.check_stop()
-
-    if not sys.platform.startswith('win'):
-        def test_sigint(self):
-            self.start_up()
-            os.kill(self.parent_process.pid, signal.SIGINT)
-
-        def test_sigint_child_locked_up(self):
-            self.start_up()
-            self.freeze_up_middle_child()
-            os.kill(self.parent_process.pid, signal.SIGINT)
-            #This needs time to wait for the child for 10 seconds:
-            self.wait_for_parent_to_stop(11)
-
-    def test_file_open_by_parent_before_fork_can_be_closed_and_deleted(self):
-        self.start_up()
-        result = self.send_parent_http_command("close_file_and_delete_it")
-        self.assertEqual("OK", result, "Command to close file and delete it failed (got response: %s)" % result)
-        self.check_stop()
-
-    def test_echo_std_err_on(self):
-        self.start_up(test_command='echo_std_err')
-        self.check_stop()
-
-    def test_handles_over_commandline_off(self):
-        if not sys.platform.startswith('win') or not CAN_USE_EXTENDED_STARTUPINFO:
-            self.skipTest("This test is not supported on this platform")
-        self.start_up(test_command='handles_over_commandline_off')
-        self.check_stop()
-
-    def test_handles_over_commandline_off_close_fds_off(self):
-        if not sys.platform.startswith('win') or not CAN_USE_EXTENDED_STARTUPINFO:
-            self.skipTest("This test is not supported on this platform")
-        self.start_up(test_command='handles_over_commandline_off_close_fds_off')
-        result = self.send_parent_http_command("close_file_and_delete_it")
-        self.assertEqual("FAIL", result, "Command to close file and delete it did not fail (got response: %s)" % result)
-        self.check_stop()
-
-    def test_close_fds_off(self):
-        self.start_up(test_command='close_fds_off')
-        result = self.send_parent_http_command("close_file_and_delete_it")
-        if sys.platform.startswith('win'):
-            #On linux this works fine
-            self.assertEqual("FAIL", result, "Command to close file and delete it did not fail (got response: %s)" % result)
-        else:
-            #TODO: a relevant test on linux?
-            pass
-        self.check_stop()
-
-    def test_child_comms_strategy_stdin_close(self):
-        self.start_up(test_command='use_cat', wait_for_children=False)
-        self.check_stop()
-
-    def test_child_comms_strategy_none(self):
-        self.start_up(test_command='use_cat_comms_none', wait_for_children=False)
-        # we don't actually have the ability to tell these children to stop
-        self.check_stop(3)
-
-    def test_child_comms_strategy_signal(self):
-        self.start_up(test_command='use_signal', wait_for_children=False)
-        # since we're not waiting for the children to start up, give them a chance to register signal handlers
-        time.sleep(0.5)
-        self.check_stop()
-
-    def test_use_job_object_off(self):
-        self.start_up(test_command=
-                      'use_job_object_off')
-        self.check_stop()
-
-    def test_cpu_affinity_off(self):
-        self.start_up(test_command='cpu_affinity_off')
-        self.check_stop()
-
-    def test_handles_over_commandline_off_file_open_by_parent(self):
-        if not sys.platform.startswith('win') or not CAN_USE_EXTENDED_STARTUPINFO:
-            self.skipTest("This test is not supported on this platform")
-        self.start_up(test_command='handles_over_commandline_off')
-        result = self.send_parent_http_command("close_file_and_delete_it")
-        self.assertEqual("OK", result, "Command to close file and delete it failed (got response: %s)" % result)
-        self.check_stop()
-
-    def freeze_up_middle_child(self):
-        #First check that we can do this fast (i.e. things aren't stuttering because of environment):
-        for i in range(5):
-            self.send_middle_child_http_command("", timeout=1)
-        self.send_middle_child_http_command("hold_gil?t=%d" % (60*10)) #Freeze up for 10 minutes
-        while True:
-            #Try and do this request until it takes longer than 1 sec - this would mean that we have successfully got stuck
-            try:
-                self.send_middle_child_http_command("", timeout=1)
-            except requests.exceptions.Timeout as t:
-                break
-
-    def check_server_ports_unbound(self):
-        bound_ports = []
-        for pnumber in range(4):
-            port = Config.get_starting_port_nr() + pnumber
-            #I just try and bind to the server port and see if I have a problem:
-            logging.info("Checking for ability to bind to port %d", port)
-            serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                if not sys.platform.startswith('win'):
-                    #On linux I need this setting cos we are starting and stopping things
-                    #so frequently that they are still in a STOP_WAIT state when I get here
-                    serversocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                serversocket.bind(("", port))
-            except Exception as e:
-                bound_ports.append(port)
-            finally:
-                serversocket.close()
-        self.assertFalse(bound_ports, "The following ports are still bound: %s" % ', '.join([str(p) for p in bound_ports]))
-
-    def get_path_to_ParentProcessPy(self):
-        return os.path.join(os.path.dirname(__file__), 'test', 'ParentProcess.py')
-
-    def send_parent_http_command(self, command, params=None, **kwargs):
-        return self.send_http_command(Config.get_starting_port_nr(), command, params=params, **kwargs)
-
-    def send_middle_child_http_command(self, command, params=None, **kwargs):
-        return self.send_http_command(Config.get_starting_port_nr()+2, command, params=params, **kwargs)
-
-    def send_http_command(self, port, command, params=None, **kwargs):
-        r = requests.get('http://localhost:%d/%s' % (port, command), params=params, **kwargs)
-        j = r.json
-        if callable(j):
-            return j()
-        else:
-            #This is the old requests api:
-            return j
-
-    def wait_for_process_to_stop(self, process, timeout):
-        if process is None:
-            logging.info("No process to wait for")
-            return
-        logging.info("Waiting for process (%d) to finish", process.pid)
-        start_time = time.time()
-        while time.time()-start_time < timeout:
-            if process.poll() is None:
-                time.sleep(0.3)
-            else:
-                return
+    @classmethod
+    def pseudo_fixture(cls, *args, **kwargs):
+        reason = cls.shouldSkip()
+        if reason is not None:
+            pytest.skip(reason)
+        instance = cls(*args, **kwargs)
+        instance.setup()
+        yield instance
+        instance.teardown()
 
 
-class NormalSubprocessTests(_BaseProcessFamilyFunkyWebServerTestSuite):
-
+class NormalSubprocessFixture(FunkyWebServerFixtureBase):
     skip_crash_test = "The crash test throws up a dialog in this context" if sys.platform.startswith('win') else None
 
     def start_parent_process(self, timeout=None):
@@ -421,179 +319,341 @@ class NormalSubprocessTests(_BaseProcessFamilyFunkyWebServerTestSuite):
         if timeout:
             environ[text_to_native_str("STARTUP_TIMEOUT")] = text_to_native_str(timeout)
         self.parent_process = subprocess.Popen(
-            list_to_native_str([sys.executable, self.get_path_to_ParentProcessPy()]),
+            list_to_native_str([sys.executable, path_to_ParentProcessPy]),
             close_fds=True, env=environ, **kwargs)
         threading.Thread(target=self.parent_process.communicate).start()
 
     def wait_for_parent_to_stop(self, timeout):
-        self.wait_for_process_to_stop(getattr(self, 'parent_process', None), timeout)
+        wait_for_process_to_stop(getattr(self, 'parent_process', None), timeout)
 
-if sys.platform.startswith('win'):
-    import win32service
-    import win32serviceutil
-    from processfamily.test.ExeBuilder import build_service_exe
-    from processfamily.processes import USE_PROCESS_QUERY_LIMITED_INFORMATION
 
-    def CanOpenSCManager():
-        s = None
-        try:
-            s = win32service.OpenSCManager(None, None, win32service.SC_MANAGER_ALL_ACCESS)
-        except:
-            return False
+@pytest.fixture()
+def normal_subprocess():
+    for x in NormalSubprocessFixture.pseudo_fixture():
+        yield x
+
+
+class PythonwFixture(FunkyWebServerFixtureBase):
+    skip_crash_test = "The crash test throws up a dialog in this context" if sys.platform.startswith('win') else None
+
+    def start_parent_process(self, timeout=None):
+
+        self.parent_process = subprocess.Popen(
+            [Config.pythonw_exe, path_to_ParentProcessPy],
+            close_fds=True,
+            creationflags=CREATE_BREAKAWAY_FROM_JOB)
+        threading.Thread(target=self.parent_process.communicate).start()
+
+    def wait_for_parent_to_stop(self, timeout):
+        wait_for_process_to_stop(getattr(self, 'parent_process', None), timeout)
+
+    @classmethod
+    def shouldSkip(cls):
+        if not sys.platform.startswith('win'):
+            return "Fixture only runs on windows"
         else:
-            return True
-        finally:
-            if s:
-                win32service.CloseServiceHandle(s)
+            return super(PythonwFixture, cls).shouldSkip()
 
 
-    class PythonWTests(_BaseProcessFamilyFunkyWebServerTestSuite):
+@pytest.fixture()
+def pythonw():
+    for x in PythonwFixture.pseudo_fixture():
+        yield x
 
-        skip_crash_test = "The crash test throws up a dialog in this context" if sys.platform.startswith('win') else None
 
-        def start_parent_process(self, timeout=None):
+# To run the tests with this fixture you must
+# make sure the file <env>\python\Lib\site-packages\win32\pywintypes<VER>.dll exists, if it does not you need to
+# copy it from <env>\python\Lib\site-packages\pywin32_system32 and put it there.
+#
+# then you must open an administrator console
+# then run pytest -k [windows_service
+# (The right ] was ommited on purpose)
+class WindowsServiceFixture(FunkyWebServerFixtureBase):
 
-            self.parent_process = subprocess.Popen(
-                [Config.pythonw_exe, self.get_path_to_ParentProcessPy()],
-                close_fds=True,
-                creationflags=CREATE_BREAKAWAY_FROM_JOB)
-            threading.Thread(target=self.parent_process.communicate).start()
+    def __init__(self, username, *args, **kwargs):
+        self.username = username
 
-        def wait_for_parent_to_stop(self, timeout):
-            self.wait_for_process_to_stop(getattr(self, 'parent_process', None), timeout)
+    def try_and_stop_everything_for_tear_down(self):
+        send_stop_and_then_wait_for_service_to_stop_ignore_errors()
 
-    # To run these tests you
-    # make sure the file <env>\python\Lib\site-packages\win32\pywintypes<VER>.dll exists, if it does not you need to
-    # copy it from <env>\python\Lib\site-packages\pywin32_system32 and put it there.
-    #
-    # then you must open an administrator console
-    # then run pytest test_processfamily::WindowsServiceTests
-    @pytest.mark.skipif(not CanOpenSCManager(), reason="These tests must be run as administrator")
-    class WindowsServiceTests(_BaseProcessFamilyFunkyWebServerTestSuite):
+    def start_parent_process(self, timeout=None):
+        win32serviceutil.StartService(Config.svc_name)
 
-        @classmethod
-        def setUpClass(cls, service_username=None):
-            cls.send_stop_and_then_wait_for_service_to_stop_ignore_errors()
-            cls.service_exe = build_service_exe()
-            cmd = [cls.service_exe] + (["--username", service_username] if service_username else []) + ["install"]
-            subprocess.check_call(list_to_native_str(cmd))
+    def wait_for_parent_to_stop(self, timeout):
+        wait_for_service_to_stop(timeout)
 
-        @classmethod
-        def tearDownClass(cls):
-            if hasattr(cls, 'service_exe'):
-                subprocess.check_call([cls.service_exe, "remove"])
+    @classmethod
+    def shouldSkip(cls):
+        if not sys.platform.startswith("win") :
+            return "Fixture only runs on windows"
+        elif not CanOpenSCManager():
+            return "Fixture must be run as an Administrator"
+        else:
+            return super(WindowsServiceFixture, cls).shouldSkip()
 
-        def try_and_stop_everything_for_tear_down(self):
-            self.send_stop_and_then_wait_for_service_to_stop_ignore_errors()
 
-        def start_parent_process(self, timeout=None):
-            win32serviceutil.StartService(Config.svc_name)
+@pytest.fixture(scope="session")
+def network_service_user_permissions():
+    # I do this just in case we left the service running by interrupting the tests
+    send_stop_and_then_wait_for_service_to_stop_ignore_errors()
+    tmp_dir = os.path.join(os.path.dirname(__file__), 'test', 'tmp')
+    if not os.path.exists(tmp_dir):
+        os.makedirs(tmp_dir)
+    # Make sure network service has full access to the tmp folder (and these are inheritable)
+    grant_network_service_rights(tmp_dir, "F")
+    # And read / execute access to Python, and other folders on the python path:
+    grant_network_service_rights(os.path.abspath(sys.prefix), "RX")
+    done_paths = [os.path.abspath(sys.prefix)]
+    for path_item in sorted(sys.path, key=lambda p: len(os.path.abspath(p))):
+        abspath_item = os.path.abspath(path_item)
+        already_done = False
+        for p in done_paths:
+            if abspath_item.startswith(p):
+                already_done = True
+                break
+        if not already_done:
+            grant_network_service_rights(abspath_item, "RX")
+            done_paths.append(abspath_item)
 
-        def wait_for_parent_to_stop(self, timeout):
-            self.wait_for_service_to_stop(timeout)
 
-        @classmethod
-        def wait_for_service_to_stop(cls, timeout):
-            start_time = time.time()
-            while time.time()-start_time < timeout:
-                if win32serviceutil.QueryServiceStatus(Config.svc_name)[1] != win32service.SERVICE_STOPPED:
-                    time.sleep(0.3)
+@pytest.fixture(scope="session", params=[None, "NT AUTHORITY\\NetworkService"])
+def service_exe(request, network_service_user_permissions):
+    reason = WindowsServiceFixture.shouldSkip()
+    if reason:
+        pytest.skip(reason)
+    service_username = request.param
+    send_stop_and_then_wait_for_service_to_stop_ignore_errors()
+    exe = build_service_exe()
+    cmd = [exe] + (["--username", service_username] if service_username else []) + ["install"]
+    subprocess.check_call(list_to_native_str(cmd))
+    yield (exe, service_username)
+    subprocess.check_call([exe, "remove"])
 
-        def test_parent_crash(self):
-            pytest.xfail("For some reason the application still is running after we crash it. I'll figure it out later")
-            super(self, WindowsServiceTests).test_parent_crash()
 
-        def test_parent_crash_child_locked_up(self):
-            pytest.xfail("For some reason the application still is running after we crash it. I'll figure it out later")
-            super(self, WindowsServiceTests).test_parent_crash_child_locked_up()
+@pytest.fixture()
+def windows_service(service_exe):
+    for x in WindowsServiceFixture.pseudo_fixture(service_exe[1]):
+        yield x
 
-        def test_parent_interrupt_main(self):
-            self.skipTest("Interrupt main doesn't do anything useful in a windows service")
 
-        def test_parent_interrupt_main_child_locked_up(self):
-            self.skipTest("Interrupt main doesn't do anything useful in a windows service")
+# If you only want to run against one fixture specify -k [fixture on the command line
+# e.g. pytest -k [normal_subprocess
+# (Closing [ is ommited on purpose)
+@pytest.fixture(params=[
+    pytest.lazy_fixture('normal_subprocess'),
+    pytest.lazy_fixture('pythonw'),
+    pytest.lazy_fixture('windows_service'),
+])
+def fws(request):
+    return request.param
 
-        def test_service_stop(self):
-            self.start_up()
-            win32serviceutil.StopService(Config.svc_name)
 
-        def test_service_stop_child_locked_up(self):
-            self.start_up()
-            self.freeze_up_middle_child()
-            win32serviceutil.StopService(Config.svc_name)
+class TestFunkyWebServer():
+
+    def test_parent_stop(self, fws):
+        fws.start_up()
+        check_stop()
+
+    def test_parent_exit(self, fws):
+        fws.start_up()
+        send_parent_http_command("exit")
+
+    def test_parent_crash(self, fws):
+        if fws.skip_crash_test:
+            pytest.skip(fws.skip_crash_test)
+        if isinstance(fws, WindowsServiceFixture):
+            pytest.xfail("Teardown is failing for some reason. We should figure it out later")
+        fws.start_up()
+        send_parent_http_command("crash")
+
+    def test_parent_interrupt_main(self, fws):
+        if isinstance(fws, WindowsServiceFixture):
+            pytest.skip("Interrupt main doesn't do anything useful in a windows service")
+        fws.start_up()
+        send_parent_http_command("interrupt_main")
+
+    def test_parent_kill(self, fws, request):
+        if isinstance(fws, WindowsServiceFixture):
+            if not USE_PROCESS_QUERY_LIMITED_INFORMATION or fws.username is not None:
+                pytest.skip("I cannot kill a network service service from here - I get an access denied error")
+        fws.start_up()
+        kill_parent()
+
+    def test_parent_stop_child_locked_up(self, fws):
+        fws.start_up()
+        freeze_up_middle_child()
+        check_stop(1, timeout=5)
+        #This needs time to wait for the child for 10 seconds:
+        fws.wait_for_parent_to_stop(11)
+
+    def test_parent_exit_child_locked_up(self, fws):
+        fws.start_up()
+        freeze_up_middle_child()
+        send_parent_http_command("exit")
+
+    def test_parent_crash_child_locked_up(self, fws):
+        if fws.skip_crash_test:
+            pytest.skip(fws.skip_crash_test)
+        if isinstance(fws, WindowsServiceFixture):
+            pytest.xfail("Teardown is failing for some reason. Figure it out later")
+        fws.start_up()
+        freeze_up_middle_child()
+        send_parent_http_command("crash")
+
+    def test_parent_interrupt_main_child_locked_up(self, fws):
+        if isinstance(fws, WindowsServiceFixture):
+            pytest.skip("Interrupt main doesn't do anything useful in a windows service")
+        fws.start_up()
+        freeze_up_middle_child()
+        send_parent_http_command("interrupt_main")
+        #This needs time to wait for the child for 10 seconds:
+        fws.wait_for_parent_to_stop(11)
+
+    def test_parent_kill_child_locked_up(self, fws, request):
+        if isinstance(fws, WindowsServiceFixture):
+            if not USE_PROCESS_QUERY_LIMITED_INFORMATION or fws.username is not None:
+                pytest.skip("I cannot kill a network service service from here - I get an access denied error")
+        fws.start_up()
+        freeze_up_middle_child()
+        kill_parent()
+
+    def test_parent_exit_child_locked_up(self, fws):
+        fws.start_up()
+        freeze_up_middle_child()
+        send_parent_http_command("exit")
+
+    def test_child_exit_on_start(self, fws):
+        fws.start_up(test_command='child_exit_on_start', wait_for_middle_child=False)
+        assert_middle_child_port_unbound()
+        check_stop()
+
+    def test_child_error_during_run(self, fws):
+        fws.start_up(test_command='child_error_during_run', wait_for_middle_child=False)
+        check_stop()
+
+    def test_child_freeze_on_start(self, fws):
+        fws.start_up(test_command='child_freeze_on_start', wait_for_middle_child=False, parent_timeout=2)
+        assert_middle_child_port_unbound()
+        check_stop(1, timeout=5)
+
+    def test_child_error_on_start(self, fws):
+        fws.start_up(test_command='child_error_on_start', wait_for_middle_child=False)
+        assert_middle_child_port_unbound()
+        check_stop()
+
+    def test_child_error_during_init(self, fws):
+        fws.start_up(test_command='child_error_during_init', wait_for_middle_child=False)
+        assert_middle_child_port_unbound()
+        check_stop()
+
+    def test_child_freeze_during_init(self, fws):
+        fws.start_up(test_command='child_freeze_during_init', wait_for_middle_child=False, parent_timeout=2)
+        assert_middle_child_port_unbound()
+        check_stop(1, timeout=5)
+        fws.wait_for_parent_to_stop(11)
+
+    def test_child_crash_on_start(self, fws):
+        if fws.skip_crash_test:
+            pytest.skip(fws.skip_crash_test)
+        fws.start_up(test_command='child_crash_on_start', wait_for_middle_child=False)
+        assert_middle_child_port_unbound()
+        check_stop()
+
+    if not sys.platform.startswith('win'):
+        def test_sigint(self, fws):
+            fws.start_up()
+            os.kill(fws.parent_process.pid, signal.SIGINT)
+
+        def test_sigint_child_locked_up(self, fws):
+            fws.start_up()
+            freeze_up_middle_child()
+            os.kill(fws.parent_process.pid, signal.SIGINT)
             #This needs time to wait for the child for 10 seconds:
-            self.wait_for_parent_to_stop(11)
+            fws.wait_for_parent_to_stop(11)
 
-        def test_service_stop_child_freeze_on_start(self):
-            self.start_up(test_command='child_freeze_on_start', wait_for_middle_child=False)
-            self.assert_middle_child_port_unbound()
-            win32serviceutil.StopService(Config.svc_name)
-            #This still needs time to wait for the child to stop for 10 seconds:
-            self.wait_for_parent_to_stop(11)
+    def test_file_open_by_parent_before_fork_can_be_closed_and_deleted(self, fws):
+        fws.start_up()
+        result = send_parent_http_command("close_file_and_delete_it")
+        assert "OK" == result, "Command to close file and delete it failed (got response: %s)" % result
+        check_stop()
 
-        @classmethod
-        def send_stop_and_then_wait_for_service_to_stop_ignore_errors(cls):
-            try:
-                win32serviceutil.StopService(Config.svc_name)
-                cls.wait_for_service_to_stop(20)
-            except Exception as e:
-                pass
+    def test_echo_std_err_on(self, fws):
+        fws.start_up(test_command='echo_std_err')
+        check_stop()
 
-        if not USE_PROCESS_QUERY_LIMITED_INFORMATION:
-            def test_parent_kill(self):
-                self.skipTest("I cannot kill a network service service from here - I get an access denied error")
+    def test_handles_over_commandline_off(self, fws):
+        if not sys.platform.startswith('win') or not CAN_USE_EXTENDED_STARTUPINFO:
+            fws.skipTest("This test is not supported on this platform")
+        fws.start_up(test_command='handles_over_commandline_off')
+        check_stop()
 
-            def test_parent_kill_child_locked_up(self):
-                self.skipTest("I cannot kill a network service service from here - I get an access denied error")
+    def test_handles_over_commandline_off_close_fds_off(self, fws):
+        if not sys.platform.startswith('win') or not CAN_USE_EXTENDED_STARTUPINFO:
+            fws.skipTest("This test is not supported on this platform")
+        fws.start_up(test_command='handles_over_commandline_off_close_fds_off')
+        result = send_parent_http_command("close_file_and_delete_it")
+        assert "FAIL" == result, "Command to close file and delete it did not fail (got response: %s)" % result
+        check_stop()
 
+    def test_close_fds_off(self, fws):
+        fws.start_up(test_command='close_fds_off')
+        result = send_parent_http_command("close_file_and_delete_it")
+        if sys.platform.startswith('win'):
+            #On linux this works fine
+            assert "FAIL" == result, "Command to close file and delete it did not fail (got response: %s)" % result
+        else:
+            #TODO: a relevant test on linux?
+            pass
+        check_stop()
 
-    # To run these tests you
-    # make sure the file <env>\python\Lib\site-packages\win32\pywintypes<VER>.dll exists, if it does not you need to
-    # copy it from <env>\python\Lib\site-packages\pywin32_system32 and put it there.
-    #
-    # then you must open an administrator console
-    # then run pytest test_processfamily::WindowsServiceTestNetworkServiceUserTests
-    class WindowsServiceNetworkServiceUserTests(WindowsServiceTests):
+    def test_child_comms_strategy_stdin_close(self, fws):
+        fws.start_up(test_command='use_cat', wait_for_children=False)
+        check_stop()
 
-        @staticmethod
-        def grant_network_service_rights(folder, rights):
-            try:
-                subprocess.check_call(["cmd.exe", "/C", "icacls", folder, "/grant", "NETWORK SERVICE:(OI)(CI)%s" % rights])
-            except Exception as e:
-                logging.warning("icacls command returned a non-zero response for folder/file '%s'")
+    def test_child_comms_strategy_none(self, fws):
+        fws.start_up(test_command='use_cat_comms_none', wait_for_children=False)
+        # we don't actually have the ability to tell these children to stop
+        check_stop(3)
 
-        @classmethod
-        def setUpClass(cls):
-            #I do this just in case we left the service running by interrupting the tests
-            cls.send_stop_and_then_wait_for_service_to_stop_ignore_errors()
+    def test_child_comms_strategy_signal(self, fws):
+        fws.start_up(test_command='use_signal', wait_for_children=False)
+        # since we're not waiting for the children to start up, give them a chance to register signal handlers
+        time.sleep(0.5)
+        check_stop()
 
-            tmp_dir = os.path.join(os.path.dirname(__file__), 'test', 'tmp')
-            if not os.path.exists(tmp_dir):
-                os.makedirs(tmp_dir)
-            #Make sure network service has full access to the tmp folder (and these are inheritable)
-            cls.grant_network_service_rights(tmp_dir, "F")
-            #And read / execute access to Python, and other folders on the python path:
-            cls.grant_network_service_rights(os.path.abspath(sys.prefix), "RX")
-            done_paths = [os.path.abspath(sys.prefix)]
-            for path_item in sorted(sys.path, key=lambda p: len(os.path.abspath(p))):
-                abspath_item = os.path.abspath(path_item)
-                already_done = False
-                for p in done_paths:
-                    if abspath_item.startswith(p):
-                        already_done = True
-                        break
-                if not already_done:
-                    cls.grant_network_service_rights(abspath_item, "RX")
-                    done_paths.append(abspath_item)
+    def test_use_job_object_off(self, fws):
+        fws.start_up(test_command=
+                      'use_job_object_off')
+        check_stop()
 
-            super(WindowsServiceNetworkServiceUserTests, cls).setUpClass(service_username="NT AUTHORITY\\NetworkService")
+    def test_cpu_affinity_off(self, fws):
+        fws.start_up(test_command='cpu_affinity_off')
+        check_stop()
 
-        def test_parent_kill(self):
-            self.skipTest("I cannot kill a network service service from here - I get an access denied error")
+    def test_handles_over_commandline_off_file_open_by_parent(self, fws):
+        if not sys.platform.startswith('win') or not CAN_USE_EXTENDED_STARTUPINFO:
+            fws.skipTest("This test is not supported on this platform")
+        fws.start_up(test_command='handles_over_commandline_off')
+        result = send_parent_http_command("close_file_and_delete_it")
+        assert "OK" == result, "Command to close file and delete it failed (got response: %s)" % result
+        check_stop()
 
-        def test_parent_kill_child_locked_up(self):
-            self.skipTest("I cannot kill a network service service from here - I get an access denied error")
+class TestWindowsService():
 
+    def test_service_stop(self, windows_service):
+        windows_service.start_up()
+        win32serviceutil.StopService(Config.svc_name)
 
-#Remove the base class from the module dict so it isn't smelled out by nose:
-del(_BaseProcessFamilyFunkyWebServerTestSuite)
+    def test_service_stop_child_locked_up(self, windows_service):
+        windows_service.start_up()
+        freeze_up_middle_child()
+        win32serviceutil.StopService(Config.svc_name)
+        #This needs time to wait for the child for 10 seconds:
+        windows_service.wait_for_parent_to_stop(11)
+
+    def test_service_stop_child_freeze_on_start(self, windows_service):
+        windows_service.start_up(test_command='child_freeze_on_start', wait_for_middle_child=False)
+        assert_middle_child_port_unbound()
+        win32serviceutil.StopService(Config.svc_name)
+        #This still needs time to wait for the child to stop for 10 seconds:
+        windows_service.wait_for_parent_to_stop(11)

--- a/processfamily/test_processfamily.py
+++ b/processfamily/test_processfamily.py
@@ -317,7 +317,7 @@ class NormalSubprocessFixture(FunkyWebServerFixtureBase):
             kwargs['creationflags'] = CREATE_BREAKAWAY_FROM_JOB
         environ = get_env_dict()
         if timeout:
-            environ[text_to_native_str("STARTUP_TIMEOUT")] = text_to_native_str(timeout)
+            environ[text_to_native_str("STARTUP_TIMEOUT")] = native_str(timeout)
         self.parent_process = subprocess.Popen(
             list_to_native_str([sys.executable, path_to_ParentProcessPy]),
             close_fds=True, env=environ, **kwargs)

--- a/processfamily/test_processfamily.py
+++ b/processfamily/test_processfamily.py
@@ -366,9 +366,9 @@ def pythonw():
 # copy it from <env>\python\Lib\site-packages\pywin32_system32 and put it there.
 #
 # then you must open an administrator console
-# then run pytest -k [windows_service
-# (The right ] was ommited on purpose)
+# then run pytest -k windows_service
 class WindowsServiceFixture(FunkyWebServerFixtureBase):
+    skip_interrupt_main = "Interrupt main doesn't do anything useful in a windows service"
 
     def __init__(self, username, *args, **kwargs):
         self.username = username
@@ -467,8 +467,8 @@ class TestFunkyWebServer():
         send_parent_http_command("crash")
 
     def test_parent_interrupt_main(self, fws):
-        if isinstance(fws, WindowsServiceFixture):
-            pytest.skip("Interrupt main doesn't do anything useful in a windows service")
+        if fws.skip_intterupt_main:
+            pytest.skip(fws.skip_intterupt_main)
         fws.start_up()
         send_parent_http_command("interrupt_main")
 

--- a/processfamily/test_processfamily.py
+++ b/processfamily/test_processfamily.py
@@ -394,6 +394,9 @@ class WindowsServiceFixture(FunkyWebServerFixtureBase):
 
 @pytest.fixture(scope="session")
 def network_service_user_permissions():
+    reason = WindowsServiceFixture.shouldSkip()
+    if reason:
+        pytest.skip(reason)
     # I do this just in case we left the service running by interrupting the tests
     send_stop_and_then_wait_for_service_to_stop_ignore_errors()
     tmp_dir = os.path.join(os.path.dirname(__file__), 'test', 'tmp')
@@ -436,9 +439,8 @@ def windows_service(service_exe):
         yield x
 
 
-# If you only want to run against one fixture specify -k [fixture on the command line
-# e.g. pytest -k [normal_subprocess
-# (Closing [ is ommited on purpose)
+# If you only want to run against one fixture specify -k fixture on the command line
+# e.g. pytest -k normal_subprocess
 @pytest.fixture(params=[
     pytest.lazy_fixture('normal_subprocess'),
     pytest.lazy_fixture('pythonw'),

--- a/processfamily/threads.py
+++ b/processfamily/threads.py
@@ -46,7 +46,7 @@ def thread_async_raise(thread, exctype):
         raise SystemError("PyThreadState_SetAsyncExc failed")
 
 def get_thread_id(thread):
-    if not thread.isAlive():
+    if not thread.is_alive():
         raise threading.ThreadError("the thread is not active")
     # Is it defined on the thread object?
     if hasattr(thread, "ident"):
@@ -88,14 +88,14 @@ def get_thread_callstr(thread):
 
 def graceful_stop_thread(thread, thread_wait=0.5):
     """try to stop the given thread gracefully if it is still alive. Returns success"""
-    if thread.isAlive():
+    if thread.is_alive():
         # this attempts to raise an exception in the thread; the sleep allows the switch or natural end of the thread
         try:
             thread_async_raise(thread, SystemExit)
         except Exception as e:
             logger.info("Error trying to raise exit message in thread %s:\n%s", thread.getName(), _traceback_str())
         time.sleep(thread_wait)
-    if thread.isAlive():
+    if thread.is_alive():
         return False
     else:
         logger.info("Thread %s stopped gracefully", thread.getName())
@@ -103,7 +103,7 @@ def graceful_stop_thread(thread, thread_wait=0.5):
 
 def forceful_stop_thread(thread):
     """stops the given thread forcefully if it is alive"""
-    if thread.isAlive():
+    if thread.is_alive():
         logger.warning("Stopping thread %s forcefully", thread.getName())
         try:
             if sys.version_info.major < 3:
@@ -112,7 +112,7 @@ def forceful_stop_thread(thread):
                 thread.stop()
         except Exception as e:
             logger.warning("Error stopping thread %s: %s", thread.getName(), e)
-    return not thread.isAlive()
+    return not thread.is_alive()
 
 def stop_thread(thread, thread_wait=1.0):
     """stops the given thread if it is still alive - first gently, then forcefully if it does not respond to an exception raise within thread_wait seconds"""
@@ -157,7 +157,7 @@ def stop_threads(global_wait=2.0, thread_wait=1.0, exclude_threads=None, log_tra
     """enumerates remaining threads and stops them"""
     current_thread = threading.currentThread()
     def find_stop_threads():
-        return [t for t in filter_threads(list(threading._active.values()), current_thread, exclude_threads, exclude_thread_fn=exclude_thread_fn) if t.isAlive()]
+        return [t for t in filter_threads(list(threading._active.values()), current_thread, exclude_threads, exclude_thread_fn=exclude_thread_fn) if t.is_alive()]
     remaining_threads = find_stop_threads()
     threads_to_stop = []
     for thread in remaining_threads:

--- a/processfamily/win32Popen.py
+++ b/processfamily/win32Popen.py
@@ -11,6 +11,7 @@ from builtins import str
 from past.builtins import basestring
 from builtins import *
 from builtins import object
+from future.utils import PY2
 __author__ = 'matth'
 
 from processfamily import _winprocess_ctypes
@@ -25,6 +26,8 @@ import logging
 import time
 
 logger = logging.getLogger("processfamily.win32Popen")
+
+# TODO Revert file to before futurize and only use these in Python 2
 
 class HandlesOverCommandLinePopen(subprocess.Popen):
     """
@@ -197,165 +200,170 @@ def open_commandline_passed_stdio_streams(args=None):
 
     win32event.SetEvent(event_handle)
 
+if PY2:
+    class ProcThreadAttributeHandleListPopen(subprocess.Popen):
+        """
+        Uses the STARTUPINFOEX struct to pass through an explicit list of
+        handles to inherit. This is used to more closely match the behaviour
+        on linux when the input and output streams are redirected, but you
+        want close_fds to be True. (This is 'not supported' in the standard
+        implementation.)
 
-class ProcThreadAttributeHandleListPopen(subprocess.Popen):
-    """
-    Uses the STARTUPINFOEX struct to pass through an explicit list of
-    handles to inherit. This is used to more closely match the behaviour
-    on linux when the input and output streams are redirected, but you
-    want close_fds to be True. (This is 'not supported' in the standard
-    implementation.)
+        Please note that this functionality requires Windows version > XP/2003.
 
-    Please note that this functionality requires Windows version > XP/2003.
+        Relevant python docs:
+        http://bugs.python.org/issue19764
+        http://legacy.python.org/dev/peps/pep-0446/
+        """
 
-    Relevant python docs:
-    http://bugs.python.org/issue19764
-    http://legacy.python.org/dev/peps/pep-0446/
-    """
+        def __init__(self, args, stdin=None, stdout=None, stderr=None, close_fds=False, shell=False, **kwargs):
+            self.__really_close_fds = close_fds
+            if close_fds and (stdin is not None or stdout is not None or stderr is not None):
+                if not _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
+                    raise ValueError("close_fds is not supported on Windows "
+                                     "platforms XP/2003 and below, if you redirect stdin/stdout/stderr")
+                if shell:
+                    raise ValueError("close_fds is not supported on Windows "
+                                     "if you redirect stdin/stdout/stderr, and use shell=True")
+                self.__really_close_fds = True
+                close_fds = False
 
-    def __init__(self, args, stdin=None, stdout=None, stderr=None, close_fds=False, shell=False, **kwargs):
-        self.__really_close_fds = close_fds
-        if close_fds and (stdin is not None or stdout is not None or stderr is not None):
-            if not _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
-                raise ValueError("close_fds is not supported on Windows "
-                                 "platforms XP/2003 and below, if you redirect stdin/stdout/stderr")
+            super(ProcThreadAttributeHandleListPopen, self).__init__(
+                args, stdin=stdin, stdout=stdout, stderr=stderr, close_fds=close_fds, shell=shell, **kwargs)
+
+
+        # This Source Code Form is subject to the terms of the Mozilla Public
+        # License, v. 2.0. If a copy of the MPL was not distributed with this file,
+        # You can obtain one at http://mozilla.org/MPL/2.0/.
+        #
+        # This snippet is a modified method taken from : https://hg.mozilla.org/mozilla-central/raw-file/0753f7b93ab7/testing/mozbase/mozprocess/mozprocess/processhandler.py
+        def _execute_child(self, *args_tuple):
+            if sys.hexversion < 0x02070600: # prior to 2.7.6
+                (args, executable, preexec_fn, close_fds,
+                 cwd, env, universal_newlines, input_startupinfo,
+                 creationflags, shell,
+                 p2cread, p2cwrite,
+                 c2pread, c2pwrite,
+                 errread, errwrite) = args_tuple
+                to_close = None
+            elif sys.hexversion > 0x03040000: # 3.4.0 and later
+                (args, executable, preexec_fn, close_fds,
+                                    pass_fds, cwd, env,
+                                    input_startupinfo, creationflags, shell,
+                                    p2cread, p2cwrite,
+                                    c2pread, c2pwrite,
+                                    errread, errwrite,
+                                    restore_signals, start_new_session) = args_tuple
+                to_close = set()
+                to_close.add(p2cread)
+                if p2cwrite is not None:
+                    to_close.add(p2cwrite)
+                to_close.add(c2pwrite)
+                if c2pread is not None:
+                    to_close.add(c2pread)
+                to_close.add(errwrite)
+                if errread is not None:
+                    to_close.add(errread)
+            else: # 2.7.6 and later
+                (args, executable, preexec_fn, close_fds,
+                 cwd, env, universal_newlines, input_startupinfo,
+                 creationflags, shell, to_close,
+                 p2cread, p2cwrite,
+                 c2pread, c2pwrite,
+                 errread, errwrite) = args_tuple
+
             if shell:
-                raise ValueError("close_fds is not supported on Windows "
-                                 "if you redirect stdin/stdout/stderr, and use shell=True")
-            self.__really_close_fds = True
-            close_fds = False
+                return super(ProcThreadAttributeHandleListPopen, self)._execute_child(*args_tuple)
 
-        super(ProcThreadAttributeHandleListPopen, self).__init__(
-            args, stdin=stdin, stdout=stdout, stderr=stderr, close_fds=close_fds, shell=shell, **kwargs)
+            close_fds = self.__really_close_fds
 
+            if not isinstance(args, basestring):
+                args = subprocess.list2cmdline(args)
 
-    # This Source Code Form is subject to the terms of the Mozilla Public
-    # License, v. 2.0. If a copy of the MPL was not distributed with this file,
-    # You can obtain one at http://mozilla.org/MPL/2.0/.
-    #
-    # This snippet is a modified method taken from : https://hg.mozilla.org/mozilla-central/raw-file/0753f7b93ab7/testing/mozbase/mozprocess/mozprocess/processhandler.py
-    def _execute_child(self, *args_tuple):
-        if sys.hexversion < 0x02070600: # prior to 2.7.6
-            (args, executable, preexec_fn, close_fds,
-             cwd, env, universal_newlines, input_startupinfo,
-             creationflags, shell,
-             p2cread, p2cwrite,
-             c2pread, c2pwrite,
-             errread, errwrite) = args_tuple
-            to_close = None
-        elif sys.hexversion > 0x03040000: # 3.4.0 and later
-            (args, executable, preexec_fn, close_fds,
-                                pass_fds, cwd, env,
-                                input_startupinfo, creationflags, shell,
-                                p2cread, p2cwrite,
-                                c2pread, c2pwrite,
-                                errread, errwrite,
-                                restore_signals, start_new_session) = args_tuple
-            to_close = set()
-            to_close.add(p2cread)
-            if p2cwrite is not None:
-                to_close.add(p2cwrite)
-            to_close.add(c2pwrite)
-            if c2pread is not None:
-                to_close.add(c2pread)
-            to_close.add(errwrite)
-            if errread is not None:
-                to_close.add(errread)
-        else: # 2.7.6 and later
-            (args, executable, preexec_fn, close_fds,
-             cwd, env, universal_newlines, input_startupinfo,
-             creationflags, shell, to_close,
-             p2cread, p2cwrite,
-             c2pread, c2pwrite,
-             errread, errwrite) = args_tuple
+            if _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
+                attribute_list_data = ()
+                startupinfoex           = _winprocess_ctypes.STARTUPINFOEX()
+                startupinfo             = startupinfoex.StartupInfo
+                startupinfo.cb          = _winprocess_ctypes.sizeof(_winprocess_ctypes.STARTUPINFOEX)
+                startupinfo_argument = startupinfoex
+            else:
+                startupinfo = _winprocess_ctypes.STARTUPINFO()
+                startupinfo_argument = startupinfo
 
-        if shell:
-            return super(ProcThreadAttributeHandleListPopen, self)._execute_child(*args_tuple)
+            if input_startupinfo is not None:
+                startupinfo.dwFlags = input_startupinfo.dwFlags
+                startupinfo.hStdInput = input_startupinfo.hStdInput
+                startupinfo.hStdOutput = input_startupinfo.hStdOutput
+                startupinfo.hStdError = input_startupinfo.hStdError
+                startupinfo.wShowWindow = input_startupinfo.wShowWindow
 
-        close_fds = self.__really_close_fds
+            inherit_handles = 0 if close_fds else 1
 
-        if not isinstance(args, basestring):
-            args = subprocess.list2cmdline(args)
+            if None not in (p2cread, c2pwrite, errwrite):
+                if close_fds:
+                    HandleArray = _winprocess_ctypes.HANDLE * 3
+                    # PY2COMPAT new_int doesn't seem to know how to convert file handles to int.
+                    # So we use the "native_int" instead.
+                    handles_to_inherit = HandleArray(native_int(p2cread), native_int(c2pwrite), native_int(errwrite))
 
-        if _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
-            attribute_list_data = ()
-            startupinfoex           = _winprocess_ctypes.STARTUPINFOEX()
-            startupinfo             = startupinfoex.StartupInfo
-            startupinfo.cb          = _winprocess_ctypes.sizeof(_winprocess_ctypes.STARTUPINFOEX)
-            startupinfo_argument = startupinfoex
-        else:
-            startupinfo = _winprocess_ctypes.STARTUPINFO()
-            startupinfo_argument = startupinfo
+                    attribute_list_data = (
+                        (
+                            _winprocess_ctypes.PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                            handles_to_inherit
+                        ),
+                    )
+                    inherit_handles = 1
 
-        if input_startupinfo is not None:
-            startupinfo.dwFlags = input_startupinfo.dwFlags
-            startupinfo.hStdInput = input_startupinfo.hStdInput
-            startupinfo.hStdOutput = input_startupinfo.hStdOutput
-            startupinfo.hStdError = input_startupinfo.hStdError
-            startupinfo.wShowWindow = input_startupinfo.wShowWindow
-
-        inherit_handles = 0 if close_fds else 1
-
-        if None not in (p2cread, c2pwrite, errwrite):
-            if close_fds:
-                HandleArray = _winprocess_ctypes.HANDLE * 3
+                startupinfo.dwFlags |= _winprocess_ctypes.STARTF_USESTDHANDLES
                 # PY2COMPAT new_int doesn't seem to know how to convert file handles to int.
                 # So we use the "native_int" instead.
-                handles_to_inherit = HandleArray(native_int(p2cread), native_int(c2pwrite), native_int(errwrite))
+                startupinfo.hStdInput = native_int(p2cread)
+                startupinfo.hStdOutput = native_int(c2pwrite)
+                startupinfo.hStdError = native_int(errwrite)
 
-                attribute_list_data = (
-                    (
-                        _winprocess_ctypes.PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
-                        handles_to_inherit
-                    ),
-                )
-                inherit_handles = 1
+            if _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
+                attribute_list = _winprocess_ctypes.ProcThreadAttributeList(attribute_list_data)
+                startupinfoex.lpAttributeList = attribute_list.value
+                creationflags |= _winprocess_ctypes.EXTENDED_STARTUPINFO_PRESENT
 
-            startupinfo.dwFlags |= _winprocess_ctypes.STARTF_USESTDHANDLES
-            # PY2COMPAT new_int doesn't seem to know how to convert file handles to int.
-            # So we use the "native_int" instead.
-            startupinfo.hStdInput = native_int(p2cread)
-            startupinfo.hStdOutput = native_int(c2pwrite)
-            startupinfo.hStdError = native_int(errwrite)
+            def _close_in_parent(fd):
+                fd.Close()
+                if to_close:
+                    to_close.remove(fd)
 
-        if _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
-            attribute_list = _winprocess_ctypes.ProcThreadAttributeList(attribute_list_data)
-            startupinfoex.lpAttributeList = attribute_list.value
-            creationflags |= _winprocess_ctypes.EXTENDED_STARTUPINFO_PRESENT
+            # create the process
+            try:
+                hp, ht, pid, tid = _winprocess_ctypes.ExtendedCreateProcess(
+                    executable, args,
+                    None, None, # No special security
+                    inherit_handles, #Inherit handles
+                    creationflags,
+                    _winprocess_ctypes.EnvironmentBlock(env) if env else None,
+                    cwd,
+                    startupinfo_argument)
+            finally:
+                # Child is launched. Close the parent's copy of those pipe
+                # handles that only the child should have open.  You need
+                # to make sure that no handles to the write end of the
+                # output pipe are maintained in this process or else the
+                # pipe will not close when the child process exits and the
+                # ReadFile will hang.
+                if p2cread is not None:
+                    _close_in_parent(p2cread)
+                if c2pwrite is not None:
+                    _close_in_parent(c2pwrite)
+                if errwrite is not None:
+                    _close_in_parent(errwrite)
 
-        def _close_in_parent(fd):
-            fd.Close()
-            if to_close:
-                to_close.remove(fd)
+            self._child_created = True
+            self._handle = subprocess.Handle(hp) if hasattr(subprocess, 'Handle') else hp
+            self._thread = ht
+            self.pid = pid
+            self.tid = tid
 
-        # create the process
-        try:
-            hp, ht, pid, tid = _winprocess_ctypes.ExtendedCreateProcess(
-                executable, args,
-                None, None, # No special security
-                inherit_handles, #Inherit handles
-                creationflags,
-                _winprocess_ctypes.EnvironmentBlock(env) if env else None,
-                cwd,
-                startupinfo_argument)
-        finally:
-            # Child is launched. Close the parent's copy of those pipe
-            # handles that only the child should have open.  You need
-            # to make sure that no handles to the write end of the
-            # output pipe are maintained in this process or else the
-            # pipe will not close when the child process exits and the
-            # ReadFile will hang.
-            if p2cread is not None:
-                _close_in_parent(p2cread)
-            if c2pwrite is not None:
-                _close_in_parent(c2pwrite)
-            if errwrite is not None:
-                _close_in_parent(errwrite)
-
-        self._child_created = True
-        self._handle = subprocess.Handle(hp) if hasattr(subprocess, 'Handle') else hp
-        self._thread = ht
-        self.pid = pid
-        self.tid = tid
-
-        ht.Close()
+            ht.Close()
+else:
+    # On Python 3.7 closefds with redirection works on windows, so we don't need to change anything.
+    # I'm not sure if this is true for early versions of Python 3
+    class ProcThreadAttributeHandleListPopen(subprocess.Popen):
+        pass

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires = ["json-rpc"] + (['pywin32', "mozprocess"] if sys.platform.startswith("win") else []),
+    install_requires = ["json-rpc", "future"] + (['pywin32', "mozprocess"] if sys.platform.startswith("win") else []),
     extras_require = {
-        'tests': ['nose', 'requests'] + (['py-exe-builder'] if sys.platform.startswith("win") else []),
+        'tests': ['pytest', 'pytest-lazy-fixture', 'requests'] + (['py-exe-builder'] if sys.platform.startswith("win") else []),
     }
 )


### PR DESCRIPTION
## Changes

### Changes made to processfamily

  - Don't use ProcThreadAttributeHandleListPopen in Python 3
    - On Python 3.7 redirecting the standard handles with `close_fds=True` works
      on Windows so using `ProcThreadAttributeHandleListPopen` is unnecessary.

### Changes made to the tests

  - Replaced `json.dumps(..., encoding=...)` with `json.dumps(...).encode(...)`
  - Add check `sys.std* is None` in addition to `sys.std*.fileno() < 0`
    - In Python 2 when one uses `pythonw.exe` the standard file handles are set
      to an invalid (negative) file descriptor
    - In Python 3 when one uses `pythonw.exe` an the standard handles are set to
      `None` instead of an invalid handle.
  - Refactored unit tests so that instead of inheriting from a base class they
    use pytest fixtures
    - This makes it much easier to select which tests with which fixture you
      want to run on PyCharm and the command line.
  - Disable ExeBuilder in Python 3 (because it doesn't work yet)
  -  Make FunkyWebserver._open_file_handle inheritable.
     - The tests expect file descriptors to be inheritable, but from Python 3.4
       onwards, file descriptors are set to be not inheritable by default.
  - Skip the WindowsServiceTests if you are not running them as Administrator


### Other changes

  - Replaced the deprecated `isAlive` function with `is_alive`
  - Add dependencies `future`, `pytest`, `pytest-lazy-fixture` and remove `nose`
    from `setup.py`


### Weird things

  - In order to get the windows service tests running you must move a dll from
    one folder in the site-packages to another.


## Unit tests status

### Passing tests

TBA

### Failing tests

TBA

## TODO

Still some Python 3 test failing.