### PR TITLE
Fix threads and Popen for Python 3

### DIFF
--- a/processfamily/test/ParentProcess.py
+++ b/processfamily/test/ParentProcess.py
@@ -105,13 +105,13 @@ if __name__ == '__main__':
                     family.start(timeout=STARTUP_TIMEOUT)
                     server_thread = threading.Thread(target=server.run)
                     server_thread.start()
-                    while server_thread.isAlive():
+                    while server_thread.is_alive():
                         server_thread.join(1)
                 except KeyboardInterrupt:
                     logging.info("Stopping...")
                     server.stop()
             finally:
-                if server_thread and server_thread.isAlive():
+                if server_thread and server_thread.is_alive():
                     server_thread.join(5)
         finally:
             stop_threads()

--- a/processfamily/test/parent_launcher.py
+++ b/processfamily/test/parent_launcher.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     t = threading.Thread(target=parent_process.wait)
     t.start()
     try:
-        while t.isAlive():
+        while t.is_alive():
             t.join(1)
     except Exception as e:
         kill_process(parent_process.pid)

--- a/processfamily/threads.py
+++ b/processfamily/threads.py
@@ -46,7 +46,7 @@ def thread_async_raise(thread, exctype):
         raise SystemError("PyThreadState_SetAsyncExc failed")
 
 def get_thread_id(thread):
-    if not thread.isAlive():
+    if not thread.is_alive():
         raise threading.ThreadError("the thread is not active")
     # Is it defined on the thread object?
     if hasattr(thread, "ident"):
@@ -88,14 +88,14 @@ def get_thread_callstr(thread):
 
 def graceful_stop_thread(thread, thread_wait=0.5):
     """try to stop the given thread gracefully if it is still alive. Returns success"""
-    if thread.isAlive():
+    if thread.is_alive():
         # this attempts to raise an exception in the thread; the sleep allows the switch or natural end of the thread
         try:
             thread_async_raise(thread, SystemExit)
         except Exception as e:
             logger.info("Error trying to raise exit message in thread %s:\n%s", thread.getName(), _traceback_str())
         time.sleep(thread_wait)
-    if thread.isAlive():
+    if thread.is_alive():
         return False
     else:
         logger.info("Thread %s stopped gracefully", thread.getName())
@@ -103,7 +103,7 @@ def graceful_stop_thread(thread, thread_wait=0.5):
 
 def forceful_stop_thread(thread):
     """stops the given thread forcefully if it is alive"""
-    if thread.isAlive():
+    if thread.is_alive():
         logger.warning("Stopping thread %s forcefully", thread.getName())
         try:
             if sys.version_info.major < 3:
@@ -112,7 +112,7 @@ def forceful_stop_thread(thread):
                 thread.stop()
         except Exception as e:
             logger.warning("Error stopping thread %s: %s", thread.getName(), e)
-    return not thread.isAlive()
+    return not thread.is_alive()
 
 def stop_thread(thread, thread_wait=1.0):
     """stops the given thread if it is still alive - first gently, then forcefully if it does not respond to an exception raise within thread_wait seconds"""
@@ -157,7 +157,7 @@ def stop_threads(global_wait=2.0, thread_wait=1.0, exclude_threads=None, log_tra
     """enumerates remaining threads and stops them"""
     current_thread = threading.currentThread()
     def find_stop_threads():
-        return [t for t in filter_threads(list(threading._active.values()), current_thread, exclude_threads, exclude_thread_fn=exclude_thread_fn) if t.isAlive()]
+        return [t for t in filter_threads(list(threading._active.values()), current_thread, exclude_threads, exclude_thread_fn=exclude_thread_fn) if t.is_alive()]
     remaining_threads = find_stop_threads()
     threads_to_stop = []
     for thread in remaining_threads:

--- a/processfamily/win32Popen.py
+++ b/processfamily/win32Popen.py
@@ -11,6 +11,7 @@ from builtins import str
 from past.builtins import basestring
 from builtins import *
 from builtins import object
+from future.utils import PY2
 __author__ = 'matth'
 
 from processfamily import _winprocess_ctypes
@@ -25,6 +26,8 @@ import logging
 import time
 
 logger = logging.getLogger("processfamily.win32Popen")
+
+# TODO Revert file to before futurize and only use these in Python 2
 
 class HandlesOverCommandLinePopen(subprocess.Popen):
     """
@@ -197,165 +200,170 @@ def open_commandline_passed_stdio_streams(args=None):
 
     win32event.SetEvent(event_handle)
 
+if PY2:
+    class ProcThreadAttributeHandleListPopen(subprocess.Popen):
+        """
+        Uses the STARTUPINFOEX struct to pass through an explicit list of
+        handles to inherit. This is used to more closely match the behaviour
+        on linux when the input and output streams are redirected, but you
+        want close_fds to be True. (This is 'not supported' in the standard
+        implementation.)
 
-class ProcThreadAttributeHandleListPopen(subprocess.Popen):
-    """
-    Uses the STARTUPINFOEX struct to pass through an explicit list of
-    handles to inherit. This is used to more closely match the behaviour
-    on linux when the input and output streams are redirected, but you
-    want close_fds to be True. (This is 'not supported' in the standard
-    implementation.)
+        Please note that this functionality requires Windows version > XP/2003.
 
-    Please note that this functionality requires Windows version > XP/2003.
+        Relevant python docs:
+        http://bugs.python.org/issue19764
+        http://legacy.python.org/dev/peps/pep-0446/
+        """
 
-    Relevant python docs:
-    http://bugs.python.org/issue19764
-    http://legacy.python.org/dev/peps/pep-0446/
-    """
+        def __init__(self, args, stdin=None, stdout=None, stderr=None, close_fds=False, shell=False, **kwargs):
+            self.__really_close_fds = close_fds
+            if close_fds and (stdin is not None or stdout is not None or stderr is not None):
+                if not _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
+                    raise ValueError("close_fds is not supported on Windows "
+                                     "platforms XP/2003 and below, if you redirect stdin/stdout/stderr")
+                if shell:
+                    raise ValueError("close_fds is not supported on Windows "
+                                     "if you redirect stdin/stdout/stderr, and use shell=True")
+                self.__really_close_fds = True
+                close_fds = False
 
-    def __init__(self, args, stdin=None, stdout=None, stderr=None, close_fds=False, shell=False, **kwargs):
-        self.__really_close_fds = close_fds
-        if close_fds and (stdin is not None or stdout is not None or stderr is not None):
-            if not _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
-                raise ValueError("close_fds is not supported on Windows "
-                                 "platforms XP/2003 and below, if you redirect stdin/stdout/stderr")
+            super(ProcThreadAttributeHandleListPopen, self).__init__(
+                args, stdin=stdin, stdout=stdout, stderr=stderr, close_fds=close_fds, shell=shell, **kwargs)
+
+
+        # This Source Code Form is subject to the terms of the Mozilla Public
+        # License, v. 2.0. If a copy of the MPL was not distributed with this file,
+        # You can obtain one at http://mozilla.org/MPL/2.0/.
+        #
+        # This snippet is a modified method taken from : https://hg.mozilla.org/mozilla-central/raw-file/0753f7b93ab7/testing/mozbase/mozprocess/mozprocess/processhandler.py
+        def _execute_child(self, *args_tuple):
+            if sys.hexversion < 0x02070600: # prior to 2.7.6
+                (args, executable, preexec_fn, close_fds,
+                 cwd, env, universal_newlines, input_startupinfo,
+                 creationflags, shell,
+                 p2cread, p2cwrite,
+                 c2pread, c2pwrite,
+                 errread, errwrite) = args_tuple
+                to_close = None
+            elif sys.hexversion > 0x03040000: # 3.4.0 and later
+                (args, executable, preexec_fn, close_fds,
+                                    pass_fds, cwd, env,
+                                    input_startupinfo, creationflags, shell,
+                                    p2cread, p2cwrite,
+                                    c2pread, c2pwrite,
+                                    errread, errwrite,
+                                    restore_signals, start_new_session) = args_tuple
+                to_close = set()
+                to_close.add(p2cread)
+                if p2cwrite is not None:
+                    to_close.add(p2cwrite)
+                to_close.add(c2pwrite)
+                if c2pread is not None:
+                    to_close.add(c2pread)
+                to_close.add(errwrite)
+                if errread is not None:
+                    to_close.add(errread)
+            else: # 2.7.6 and later
+                (args, executable, preexec_fn, close_fds,
+                 cwd, env, universal_newlines, input_startupinfo,
+                 creationflags, shell, to_close,
+                 p2cread, p2cwrite,
+                 c2pread, c2pwrite,
+                 errread, errwrite) = args_tuple
+
             if shell:
-                raise ValueError("close_fds is not supported on Windows "
-                                 "if you redirect stdin/stdout/stderr, and use shell=True")
-            self.__really_close_fds = True
-            close_fds = False
+                return super(ProcThreadAttributeHandleListPopen, self)._execute_child(*args_tuple)
 
-        super(ProcThreadAttributeHandleListPopen, self).__init__(
-            args, stdin=stdin, stdout=stdout, stderr=stderr, close_fds=close_fds, shell=shell, **kwargs)
+            close_fds = self.__really_close_fds
 
+            if not isinstance(args, basestring):
+                args = subprocess.list2cmdline(args)
 
-    # This Source Code Form is subject to the terms of the Mozilla Public
-    # License, v. 2.0. If a copy of the MPL was not distributed with this file,
-    # You can obtain one at http://mozilla.org/MPL/2.0/.
-    #
-    # This snippet is a modified method taken from : https://hg.mozilla.org/mozilla-central/raw-file/0753f7b93ab7/testing/mozbase/mozprocess/mozprocess/processhandler.py
-    def _execute_child(self, *args_tuple):
-        if sys.hexversion < 0x02070600: # prior to 2.7.6
-            (args, executable, preexec_fn, close_fds,
-             cwd, env, universal_newlines, input_startupinfo,
-             creationflags, shell,
-             p2cread, p2cwrite,
-             c2pread, c2pwrite,
-             errread, errwrite) = args_tuple
-            to_close = None
-        elif sys.hexversion > 0x03040000: # 3.4.0 and later
-            (args, executable, preexec_fn, close_fds,
-                                pass_fds, cwd, env,
-                                input_startupinfo, creationflags, shell,
-                                p2cread, p2cwrite,
-                                c2pread, c2pwrite,
-                                errread, errwrite,
-                                restore_signals, start_new_session) = args_tuple
-            to_close = set()
-            to_close.add(p2cread)
-            if p2cwrite is not None:
-                to_close.add(p2cwrite)
-            to_close.add(c2pwrite)
-            if c2pread is not None:
-                to_close.add(c2pread)
-            to_close.add(errwrite)
-            if errread is not None:
-                to_close.add(errread)
-        else: # 2.7.6 and later
-            (args, executable, preexec_fn, close_fds,
-             cwd, env, universal_newlines, input_startupinfo,
-             creationflags, shell, to_close,
-             p2cread, p2cwrite,
-             c2pread, c2pwrite,
-             errread, errwrite) = args_tuple
+            if _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
+                attribute_list_data = ()
+                startupinfoex           = _winprocess_ctypes.STARTUPINFOEX()
+                startupinfo             = startupinfoex.StartupInfo
+                startupinfo.cb          = _winprocess_ctypes.sizeof(_winprocess_ctypes.STARTUPINFOEX)
+                startupinfo_argument = startupinfoex
+            else:
+                startupinfo = _winprocess_ctypes.STARTUPINFO()
+                startupinfo_argument = startupinfo
 
-        if shell:
-            return super(ProcThreadAttributeHandleListPopen, self)._execute_child(*args_tuple)
+            if input_startupinfo is not None:
+                startupinfo.dwFlags = input_startupinfo.dwFlags
+                startupinfo.hStdInput = input_startupinfo.hStdInput
+                startupinfo.hStdOutput = input_startupinfo.hStdOutput
+                startupinfo.hStdError = input_startupinfo.hStdError
+                startupinfo.wShowWindow = input_startupinfo.wShowWindow
 
-        close_fds = self.__really_close_fds
+            inherit_handles = 0 if close_fds else 1
 
-        if not isinstance(args, basestring):
-            args = subprocess.list2cmdline(args)
+            if None not in (p2cread, c2pwrite, errwrite):
+                if close_fds:
+                    HandleArray = _winprocess_ctypes.HANDLE * 3
+                    # PY2COMPAT new_int doesn't seem to know how to convert file handles to int.
+                    # So we use the "native_int" instead.
+                    handles_to_inherit = HandleArray(native_int(p2cread), native_int(c2pwrite), native_int(errwrite))
 
-        if _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
-            attribute_list_data = ()
-            startupinfoex           = _winprocess_ctypes.STARTUPINFOEX()
-            startupinfo             = startupinfoex.StartupInfo
-            startupinfo.cb          = _winprocess_ctypes.sizeof(_winprocess_ctypes.STARTUPINFOEX)
-            startupinfo_argument = startupinfoex
-        else:
-            startupinfo = _winprocess_ctypes.STARTUPINFO()
-            startupinfo_argument = startupinfo
+                    attribute_list_data = (
+                        (
+                            _winprocess_ctypes.PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                            handles_to_inherit
+                        ),
+                    )
+                    inherit_handles = 1
 
-        if input_startupinfo is not None:
-            startupinfo.dwFlags = input_startupinfo.dwFlags
-            startupinfo.hStdInput = input_startupinfo.hStdInput
-            startupinfo.hStdOutput = input_startupinfo.hStdOutput
-            startupinfo.hStdError = input_startupinfo.hStdError
-            startupinfo.wShowWindow = input_startupinfo.wShowWindow
-
-        inherit_handles = 0 if close_fds else 1
-
-        if None not in (p2cread, c2pwrite, errwrite):
-            if close_fds:
-                HandleArray = _winprocess_ctypes.HANDLE * 3
+                startupinfo.dwFlags |= _winprocess_ctypes.STARTF_USESTDHANDLES
                 # PY2COMPAT new_int doesn't seem to know how to convert file handles to int.
                 # So we use the "native_int" instead.
-                handles_to_inherit = HandleArray(native_int(p2cread), native_int(c2pwrite), native_int(errwrite))
+                startupinfo.hStdInput = native_int(p2cread)
+                startupinfo.hStdOutput = native_int(c2pwrite)
+                startupinfo.hStdError = native_int(errwrite)
 
-                attribute_list_data = (
-                    (
-                        _winprocess_ctypes.PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
-                        handles_to_inherit
-                    ),
-                )
-                inherit_handles = 1
+            if _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
+                attribute_list = _winprocess_ctypes.ProcThreadAttributeList(attribute_list_data)
+                startupinfoex.lpAttributeList = attribute_list.value
+                creationflags |= _winprocess_ctypes.EXTENDED_STARTUPINFO_PRESENT
 
-            startupinfo.dwFlags |= _winprocess_ctypes.STARTF_USESTDHANDLES
-            # PY2COMPAT new_int doesn't seem to know how to convert file handles to int.
-            # So we use the "native_int" instead.
-            startupinfo.hStdInput = native_int(p2cread)
-            startupinfo.hStdOutput = native_int(c2pwrite)
-            startupinfo.hStdError = native_int(errwrite)
+            def _close_in_parent(fd):
+                fd.Close()
+                if to_close:
+                    to_close.remove(fd)
 
-        if _winprocess_ctypes.CAN_USE_EXTENDED_STARTUPINFO:
-            attribute_list = _winprocess_ctypes.ProcThreadAttributeList(attribute_list_data)
-            startupinfoex.lpAttributeList = attribute_list.value
-            creationflags |= _winprocess_ctypes.EXTENDED_STARTUPINFO_PRESENT
+            # create the process
+            try:
+                hp, ht, pid, tid = _winprocess_ctypes.ExtendedCreateProcess(
+                    executable, args,
+                    None, None, # No special security
+                    inherit_handles, #Inherit handles
+                    creationflags,
+                    _winprocess_ctypes.EnvironmentBlock(env) if env else None,
+                    cwd,
+                    startupinfo_argument)
+            finally:
+                # Child is launched. Close the parent's copy of those pipe
+                # handles that only the child should have open.  You need
+                # to make sure that no handles to the write end of the
+                # output pipe are maintained in this process or else the
+                # pipe will not close when the child process exits and the
+                # ReadFile will hang.
+                if p2cread is not None:
+                    _close_in_parent(p2cread)
+                if c2pwrite is not None:
+                    _close_in_parent(c2pwrite)
+                if errwrite is not None:
+                    _close_in_parent(errwrite)
 
-        def _close_in_parent(fd):
-            fd.Close()
-            if to_close:
-                to_close.remove(fd)
+            self._child_created = True
+            self._handle = subprocess.Handle(hp) if hasattr(subprocess, 'Handle') else hp
+            self._thread = ht
+            self.pid = pid
+            self.tid = tid
 
-        # create the process
-        try:
-            hp, ht, pid, tid = _winprocess_ctypes.ExtendedCreateProcess(
-                executable, args,
-                None, None, # No special security
-                inherit_handles, #Inherit handles
-                creationflags,
-                _winprocess_ctypes.EnvironmentBlock(env) if env else None,
-                cwd,
-                startupinfo_argument)
-        finally:
-            # Child is launched. Close the parent's copy of those pipe
-            # handles that only the child should have open.  You need
-            # to make sure that no handles to the write end of the
-            # output pipe are maintained in this process or else the
-            # pipe will not close when the child process exits and the
-            # ReadFile will hang.
-            if p2cread is not None:
-                _close_in_parent(p2cread)
-            if c2pwrite is not None:
-                _close_in_parent(c2pwrite)
-            if errwrite is not None:
-                _close_in_parent(errwrite)
-
-        self._child_created = True
-        self._handle = subprocess.Handle(hp) if hasattr(subprocess, 'Handle') else hp
-        self._thread = ht
-        self.pid = pid
-        self.tid = tid
-
-        ht.Close()
+            ht.Close()
+else:
+    # On Python 3.7 closefds with redirection works on windows, so we don't need to change anything.
+    # I'm not sure if this is true for early versions of Python 3
+    class ProcThreadAttributeHandleListPopen(subprocess.Popen):
+        pass


### PR DESCRIPTION
On Python 3, `ProcThreadAttributeHandleListPopen.poll` was always returning None meaning we can never tell when a process exits, which is really bad.

I just replaced `ProcThreadAttributeHandleListPopen` on Python 3 with an empty subclass of `subprocess.Popen` because the [bug](http://bugs.python.org/issue19764) we were trying to work around was fixed in Python 3.7. This does mean we only support Python 3.7 and up, but that's probably fine.

I had to do some miscellaneous fixes to processfamily.threads to get them working on Python 3. 

I also replaced `isAlive` with `is_alive` because `isAlive` is deprecated.
