### PR TITLE
Change the default behavior to never inherit the processor affinity from the parent, and add a new strategy for this behavior

### DIFF
--- a/processfamily/__init__.py
+++ b/processfamily/__init__.py
@@ -370,9 +370,10 @@ class ChildCommsStrategy(object):
 #being killed
 _global_process_job_handle = None
 
-CPU_AFFINITY_STRATEGY_NONE = 0
-CPU_AFFINITY_STRATEGY_CHILDREN_ONLY = 1
-CPU_AFFINITY_STRATEGY_PARENT_INCLUDED = 2
+CPU_AFFINITY_STRATEGY_INHERIT = 0  # By default, process affinity masks are inherited by child processes. This retains that behavior
+CPU_AFFINITY_STRATEGY_CHILDREN_ONLY = 1  # Only the child processes that are spawned will get their processes affinity tied to a core
+CPU_AFFINITY_STRATEGY_PARENT_INCLUDED = 2  # Like the above, except that the parent process also gets it affinity tied to a core
+CPU_AFFINITY_STRATEGY_NONE = 3  # This overrides any default defined by the OS and allows spawned processes to float regardless of the affinity of the parent
 
 
 class NoCommsStrategy(ChildCommsStrategy):
@@ -663,6 +664,10 @@ class ProcessFamily(object):
         i = child_index+1 if self.CPU_AFFINITY_STRATEGY == CPU_AFFINITY_STRATEGY_PARENT_INCLUDED else child_index
         set_processor_affinity([i%self.cpu_count], pid=pid)
 
+    def allow_child_to_float(self, pid):
+        """ Allows the process given by pid to not be tied to any of the cores. """
+        set_processor_affinity(list(range(self.cpu_count)), pid=pid)
+
     def start(self, timeout=30):
         if self.child_processes:
             raise Exception("Invalid state: start() can only be called once")
@@ -681,11 +686,15 @@ class ProcessFamily(object):
             logger.debug("Commandline for %s: %s", self.get_child_name(i), json.dumps(cmd))
             p = self.get_Popen_class()(cmd, **self.get_Popen_kwargs(i, close_fds=self.CLOSE_FDS))
 
-            if self.CPU_AFFINITY_STRATEGY and p.poll() is None:
+            if p.poll() is None:
                 try:
-                    self.set_child_affinity_mask(p.pid, i)
+                    if self.CPU_AFFINITY_STRATEGY in [CPU_AFFINITY_STRATEGY_CHILDREN_ONLY, CPU_AFFINITY_STRATEGY_PARENT_INCLUDED]:
+                        self.set_child_affinity_mask(p.pid, i)
+                    elif self.CPU_AFFINITY_STRATEGY == CPU_AFFINITY_STRATEGY_NONE:
+                        self.allow_child_to_float(p.pid)
                 except Exception as e:
                     logger.error("Unable to set affinity for %s process %d: %s", self.get_child_name(i), p.pid, e)
+
             self.child_processes.append(self.CHILD_COMMS_STRATEGY(p, self.ECHO_STD_ERR, i, self))
 
         if sys.platform.startswith('win') and self.WIN_PASS_HANDLES_OVER_COMMANDLINE:

--- a/processfamily/test/ParentProcess.py
+++ b/processfamily/test/ParentProcess.py
@@ -53,7 +53,7 @@ class ProcessFamilyForTests(processfamily.ProcessFamily):
             elif command == 'use_job_object_off':
                 self.WIN_USE_JOB_OBJECT = False
             elif command == 'cpu_affinity_off':
-                self.CPU_AFFINITY_STRATEGY = None
+                self.CPU_AFFINITY_STRATEGY = processfamily.CPU_AFFINITY_STRATEGY_INHERIT
             elif command == 'use_cat' or command == 'use_cat_comms_none':
                 self.WIN_PASS_HANDLES_OVER_COMMANDLINE = False
                 self.CHILD_COMMS_STRATEGY = processfamily.CHILD_COMMS_STRATEGY_PIPES_CLOSE if command == 'use_cat' else processfamily.CHILD_COMMS_STRATEGY_NONE

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 setup(
     name='processfamily',
-    version='0.6',
+    version='0.6.1',
     packages = find_packages(),
     license='Apache License, Version 2.0',
     description='A library for launching, maintaining, and terminating a family of long-lived python child processes on Windows and *nix.',


### PR DESCRIPTION
If `CPU_AFFINITY_STRATEGY_NONE` is configured as the strategy for a `ProcessFamily` then the child processes will inherit the processor affinity of the parent. (This occurs on both Windows and Linux)

This is often undesirable, for instance when a user has pinned the master process to a specific core for testing, all children `CPU_AFFINITY_STRATEGY_NONE` will end up getting pinned to that core as well.

This PR changes the default behavior `CPU_AFFINITY_STRATEGY_NONE` to instead allow child processes to float between cores. A new strategy called `CPU_AFFINITY_STRATEGY_INHERIT` is added to allow children to retain the inherited processor affinity if desired.

Tests are broken on Python2 so tests will be left for the port.