### PR TITLE
build: fix wheel built on windows not working on linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires = ["json-rpc", "future"] + (['pywin32', "mozprocess"] if sys.platform.startswith("win") else []),
+    install_requires = ["json-rpc", "future", "pywin32;platform_system=='Windows'", "mozprocess;platform_system=='Windows'"],
     extras_require = {
-        'tests': ['pytest', 'pytest-lazy-fixture', 'requests'] + (['py-exe-builder'] if sys.platform.startswith("win") else []),
+        'tests': ['pytest', 'pytest-lazy-fixture', 'requests', "py-exe-builder;platform_system=='Windows'"],
     }
 )


### PR DESCRIPTION
If you build a wheel of windows it will unconditionally add pywin32 and mozprocess as dependencies. But you cannot install these packages on linux.

Instead of using `if sys.platform.startswith("win32")` which is evaluated at build time (not install time!), use environment markers as documented in https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#platform-specific-dependencies

In Draft because I haven't done any testing.